### PR TITLE
Load schedule data for adjacent weeks to avoid empty days in calendar…

### DIFF
--- a/packages/player-ui-components/src/components/schedule/MonthlyView.tsx
+++ b/packages/player-ui-components/src/components/schedule/MonthlyView.tsx
@@ -139,22 +139,20 @@ const MonthlyView: React.FC<MonthlyViewProps> = ({
                                         !dayObj.isEmpty && isSameDay(dayObj.date, new Date())
                                             ? 'primary.contrastText'
                                             : dayObj.isEmpty
-                                              ? 'text.disabled'
-                                              : 'text.primary',
+                                                ? 'text.disabled'
+                                                : 'text.primary',
                                 }}
                             >
                                 {format(dayObj.date, 'd')}
                             </Typography>
                         </Box>
-                        {!dayObj.isEmpty && (
-                            <Box sx={{ mt: 1 }}>
-                                {scheduledPlaylists
-                                    .filter((schedule) => isSameDay(new Date(schedule.date), dayObj.date))
-                                    .map((playlist, playlistIndex, array) =>
-                                        renderScheduledPlaylist(playlist, playlistIndex, array),
-                                    )}
-                            </Box>
-                        )}
+                        <Box sx={{ mt: 1 }}>
+                            {scheduledPlaylists
+                                .filter((schedule) => isSameDay(new Date(schedule.date), dayObj.date))
+                                .map((playlist, playlistIndex, array) =>
+                                    renderScheduledPlaylist(playlist, playlistIndex, array),
+                                )}
+                        </Box>
                     </DayCell>
                 ))}
             </Box>


### PR DESCRIPTION
fixed #74 