### PR TITLE
Minimize disruptions to playing playlists #53

### DIFF
--- a/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
@@ -724,6 +724,7 @@ parentPort.on('message', async (command: PlayerCommand) => {
             const fullRestart = folderChanged || command.forceRestart;
 
             if (fullRestart) {
+                pendingFullRebuild = true;
                 if (running) {
                     shouldRestart = true;
                     await running; // wait for loop to exit
@@ -986,6 +987,12 @@ let isStopped = false;
 // processQueue detects this, breaks out of its loop, and the handler
 // starts a fresh processQueue that reinitializes controllers & frame buffer.
 let shouldRestart = false;
+
+// Set when the next installNewSchedule() must do a full rebuild of the run states
+// (folder change or an explicit forceRestart / "reload" from the UI) rather than a
+// nondisruptive reconcile. This is the nuclear path: it discards live runtime state
+// (interactive queue, immediate item, stopped schedules, exact cursor position).
+let pendingFullRebuild = false;
 
 let mp3Cache: MP3PrefetchCache | undefined = undefined;
 let fseqCache: FSeqPrefetchCache | undefined = undefined;
@@ -1680,42 +1687,47 @@ async function processQueue() {
 
             // See if a schedule update has been passed in.  If so, do something.
             if (installNewSchedule()) {
-                emitInfo(`New schedule installed`);
                 const initializeTime = rtcConverter.computeTime(curPN); // MoC - Review
-                const preserveFGFseqTime = foregroundPlayerRunState?.currentTime || initializeTime;
-                const preserveBGFseqTime = backgroundPlayerRunState?.currentTime || initializeTime;
-                foregroundPlayerRunState = new PlayerRunState(initializeTime);
-                backgroundPlayerRunState = new PlayerRunState(initializeTime);
+                const mainSched = (curSchedule ?? []).filter((s) => s.scheduleType === 'main');
+                const bgSched = (curSchedule ?? []).filter((s) => s.scheduleType === 'background');
                 const errs: string[] = [];
-                foregroundPlayerRunState.setUpSequences(
-                    curSequences ?? [],
-                    curPlaylists ?? [],
-                    (curSchedule ?? []).filter((s) => s.scheduleType === 'main'),
-                    errs,
-                );
-                backgroundPlayerRunState.setUpSequences(
-                    curSequences ?? [],
-                    curPlaylists ?? [],
-                    (curSchedule ?? []).filter((s) => s.scheduleType === 'background'),
-                    errs,
-                );
-                foregroundPlayerRunState.addTimeRangeToSchedule(
-                    initializeTime,
-                    initializeTime + playbackParams.scheduleLoadTime,
-                );
-                backgroundPlayerRunState.addTimeRangeToSchedule(
-                    initializeTime,
-                    initializeTime + playbackParams.scheduleLoadTime,
-                );
 
-                lastPRSSchedUpdate = initializeTime + playbackParams.scheduleLoadTime;
+                // Rebuild when forced (reload / folder change) or when nothing is
+                // playing, since there is nothing to disturb. Otherwise reconcile the
+                // update into the running state so unrelated edits don't interrupt it.
+                const playing = foregroundPlayerRunState.isPlaying || backgroundPlayerRunState.isPlaying;
+
+                if (pendingFullRebuild || !playing) {
+                    pendingFullRebuild = false;
+                    emitInfo(`New schedule installed (rebuild)`);
+                    const preserveFGFseqTime = foregroundPlayerRunState?.currentTime || initializeTime;
+                    const preserveBGFseqTime = backgroundPlayerRunState?.currentTime || initializeTime;
+                    foregroundPlayerRunState = new PlayerRunState(initializeTime);
+                    backgroundPlayerRunState = new PlayerRunState(initializeTime);
+                    foregroundPlayerRunState.setUpSequences(curSequences ?? [], curPlaylists ?? [], mainSched, errs);
+                    backgroundPlayerRunState.setUpSequences(curSequences ?? [], curPlaylists ?? [], bgSched, errs);
+                    foregroundPlayerRunState.addTimeRangeToSchedule(
+                        initializeTime,
+                        initializeTime + playbackParams.scheduleLoadTime,
+                    );
+                    backgroundPlayerRunState.addTimeRangeToSchedule(
+                        initializeTime,
+                        initializeTime + playbackParams.scheduleLoadTime,
+                    );
+                    lastPRSSchedUpdate = initializeTime + playbackParams.scheduleLoadTime;
+
+                    // Make these caught up to the correct times from the last trip through...
+                    foregroundPlayerRunState.runUntil(preserveFGFseqTime);
+                    backgroundPlayerRunState.runUntil(preserveBGFseqTime);
+                } else {
+                    emitInfo(`New schedule installed (reconcile)`);
+                    foregroundPlayerRunState.applyDataUpdate(curSequences ?? [], curPlaylists ?? [], mainSched, errs);
+                    backgroundPlayerRunState.applyDataUpdate(curSequences ?? [], curPlaylists ?? [], bgSched, errs);
+                }
+
                 if (errs.length) {
                     emitError(`New schedule install errors: ${errs.join('\n')}`);
                 }
-
-                // Make these caught up to the correct times from the last trip through...
-                foregroundPlayerRunState.runUntil(preserveFGFseqTime);
-                backgroundPlayerRunState.runUntil(preserveBGFseqTime);
 
                 sendPlayerStateUpdate();
             }
@@ -1748,7 +1760,7 @@ async function processQueue() {
 
                         if (action.seqId) {
                             emitAudioDebug(`Do prefetch of ${action.seqId}`);
-                            const seq = foregroundPlayerRunState.sequencesById.get(action.seqId);
+                            const seq = action.seq;
                             let saf = seq?.files?.audio;
                             if (saf && !path.isAbsolute(saf)) saf = path.join(showFolder!, saf);
                             if (saf) {
@@ -1800,7 +1812,7 @@ async function processQueue() {
                         if (!action.seqId) continue;
                         if (action.end) continue;
                         const actStart = action.atTime;
-                        const seq = runState.sequencesById.get(action.seqId);
+                        const seq = action.seq;
                         if (!seq) continue;
                         // Always fetch header
                         let fsf = seq.files?.fseq;
@@ -1903,7 +1915,7 @@ async function processQueue() {
 
                 let audioref: ReturnType<MP3PrefetchCache['getMp3']> | undefined = undefined;
                 try {
-                    const curAudioSeq = foregroundPlayerRunState.sequencesById.get(audioAction.seqId);
+                    const curAudioSeq = audioAction.seq;
                     let saf = curAudioSeq?.files?.audio;
                     if (saf && !path.isAbsolute(saf)) saf = path.join(showFolder!, saf);
                     if (saf) {
@@ -2021,7 +2033,7 @@ async function processQueue() {
                 continue;
             }
 
-            const curForegroundSeq = foregroundPlayerRunState.sequencesById.get(foregroundAction.seqId);
+            const curForegroundSeq = foregroundAction.seq;
             let fsf = curForegroundSeq?.files?.fseq;
             if (fsf && !path.isAbsolute(fsf)) fsf = path.join(showFolder!, fsf);
             if (!fsf) {
@@ -2051,7 +2063,7 @@ async function processQueue() {
             const backgroundAction = upcomingBackground.curPLActions?.actions[0];
             let bframeRef: FrameReference | undefined = undefined;
             if (backgroundAction?.seqId) {
-                const curBackgroundSeq = backgroundPlayerRunState.sequencesById.get(backgroundAction.seqId);
+                const curBackgroundSeq = backgroundAction.seq;
                 let bsf = curBackgroundSeq?.files?.fseq;
                 if (bsf && !path.isAbsolute(bsf)) bsf = path.join(showFolder!, bsf);
                 if (!bsf) {

--- a/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
@@ -1721,8 +1721,24 @@ async function processQueue() {
                     backgroundPlayerRunState.runUntil(preserveBGFseqTime);
                 } else {
                     emitInfo(`New schedule installed (reconcile)`);
-                    foregroundPlayerRunState.applyDataUpdate(curSequences ?? [], curPlaylists ?? [], mainSched, errs);
-                    backgroundPlayerRunState.applyDataUpdate(curSequences ?? [], curPlaylists ?? [], bgSched, errs);
+                    // Rebuild heap/upcoming over the window already loaded ahead of now.
+                    const refillEnd = Math.max(lastPRSSchedUpdate, initializeTime);
+                    foregroundPlayerRunState.applyDataUpdate(
+                        curSequences ?? [],
+                        curPlaylists ?? [],
+                        mainSched,
+                        errs,
+                        initializeTime,
+                        refillEnd,
+                    );
+                    backgroundPlayerRunState.applyDataUpdate(
+                        curSequences ?? [],
+                        curPlaylists ?? [],
+                        bgSched,
+                        errs,
+                        initializeTime,
+                        refillEnd,
+                    );
                 }
 
                 if (errs.length) {

--- a/packages/ezplayer-core/src/util/schedulecomp.ts
+++ b/packages/ezplayer-core/src/util/schedulecomp.ts
@@ -1419,21 +1419,44 @@ export class PlayerRunState {
 
     /**
      * Adopt updated sequence/playlist/schedule data into a running state. The master
-     * maps become current truth while all runtime state — stack, heap, upcoming
-     * occurrences, interactive queue, immediate item, stoppedIds — is preserved.
+     * maps become current truth. The stack (live and suspended playback) is left
+     * untouched and keeps its captured per-position records, so what is playing is
+     * unaffected; reconciling the active stack per case is layered on top of this.
      *
-     * Items already loaded carry their own captured sequence records (the per-position
-     * PlaybackItem section arrays), so in-flight playback is unaffected by the new
-     * data. Reconciling loaded occurrences to accepted changes — re-baking, dropping
-     * deleted entries, admitting new schedules — is handled per case on top of this.
+     * Heap and upcoming occurrences carry no cursor, so they are discarded and rebuilt
+     * from the new data over [refillStart, refillEnd] (the currently loaded window).
+     * The stack and manually-stopped ids are skipped during the refill. Interactive
+     * requests whose target no longer exists are dropped.
      */
     applyDataUpdate(
         seqs: SequenceRecord[],
         playlists: PlaylistRecord[],
         schedules: ScheduledPlaylist[],
         errs: string[],
+        refillStart: number,
+        refillEnd: number,
     ) {
         this.#setMasterData(seqs, playlists, schedules, errs);
+
+        this.heap = new SchedulerMinHeap<PlaybackItem>();
+        this.heapById = new Map();
+        this.upcomingOccurrences = [];
+        this.upcomingById = new Map();
+
+        this.interactiveQueue = this.interactiveQueue.filter((q) => this.#requestResolves(q));
+        if (this.immediateItem && !this.#requestResolves(this.immediateItem)) {
+            this.immediateItem = undefined;
+        }
+
+        this.addTimeRangeToSchedule(refillStart, refillEnd);
+    }
+
+    /** Whether an interactive request still points at data that exists. */
+    #requestResolves(cmd: InteractivePlayCommand): boolean {
+        if (cmd.seqId !== undefined) return this.sequencesById.has(cmd.seqId);
+        if (cmd.playlistId !== undefined) return this.playlistsById.has(cmd.playlistId);
+        if (cmd.scheduleId !== undefined) return this.schedulesById.has(cmd.scheduleId);
+        return true;
     }
 
     /** File paths pinned by loaded playback items (stack, heap, upcoming), counted

--- a/packages/ezplayer-core/src/util/schedulecomp.ts
+++ b/packages/ezplayer-core/src/util/schedulecomp.ts
@@ -1419,14 +1419,18 @@ export class PlayerRunState {
 
     /**
      * Adopt updated sequence/playlist/schedule data into a running state. The master
-     * maps become current truth. The stack (live and suspended playback) is left
-     * untouched and keeps its captured per-position records, so what is playing is
-     * unaffected; reconciling the active stack per case is layered on top of this.
+     * maps become current truth.
      *
      * Heap and upcoming occurrences carry no cursor, so they are discarded and rebuilt
      * from the new data over [refillStart, refillEnd] (the currently loaded window).
-     * The stack and manually-stopped ids are skipped during the refill. Interactive
+     * The stack and manually-stopped ids are skipped during the refill, and interactive
      * requests whose target no longer exists are dropped.
+     *
+     * The stack keeps its captured per-position records, so what is playing is
+     * unaffected — except that an active scheduled entry whose end time moved has it
+     * accepted, and one whose schedule was deleted is wound down to end. Start-time,
+     * playlist, priority and other edits to a running schedule are left frozen; reload
+     * applies those.
      */
     applyDataUpdate(
         seqs: SequenceRecord[],
@@ -1437,6 +1441,7 @@ export class PlayerRunState {
         refillEnd: number,
     ) {
         this.#setMasterData(seqs, playlists, schedules, errs);
+        this.#reconcileActiveSchedules();
 
         this.heap = new SchedulerMinHeap<PlaybackItem>();
         this.heapById = new Map();
@@ -1449,6 +1454,29 @@ export class PlayerRunState {
         }
 
         this.addTimeRangeToSchedule(refillStart, refillEnd);
+    }
+
+    /** Reconcile active stack entries against the new schedule data. A scheduled entry
+     *  whose schedule was deleted is wound down by bringing its end to now (the entry's
+     *  endPolicy then governs how it stops); one whose end time moved has it accepted.
+     *  Start-time, playlist, priority and other edits are left frozen — reload applies
+     *  those. Safe on suspended entries too: a lowered end just takes effect on resume. */
+    #reconcileActiveSchedules() {
+        for (const entry of this.stack) {
+            if (entry.item.itemType !== 'Scheduled' || !entry.item.scheduleId) continue;
+            const sched = this.schedulesById.get(entry.item.scheduleId);
+            if (!sched) {
+                entry.item.schedEnd = Math.min(entry.item.schedEnd, this.currentTime);
+                entry.schedEndTime = entry.item.schedEnd;
+                continue;
+            }
+            const times = getScheduleTimes(sched);
+            if (times.startTimeMS !== entry.item.schedStart) continue; // start moved → reload
+            if (times.endTimeMS !== entry.item.schedEnd) {
+                entry.item.schedEnd = times.endTimeMS;
+                entry.schedEndTime = times.endTimeMS;
+            }
+        }
     }
 
     /** Whether an interactive request still points at data that exists. */

--- a/packages/ezplayer-core/src/util/schedulecomp.ts
+++ b/packages/ezplayer-core/src/util/schedulecomp.ts
@@ -614,6 +614,9 @@ export interface PlayAction {
     end: boolean;
     /** The seq ID (if applicable) */
     seqId?: string;
+    /** The sequence record as captured when the owning item was populated. Resolve
+     *  files and other detail from here so playback is unaffected by later updates. */
+    seq?: SequenceRecord;
     /** Offset into the sequence (at atTime) */
     offsetMS?: number;
     /** Duration of the action - this is the amount remaining as of atTime, until another action would occur */
@@ -650,7 +653,7 @@ class PlaybackStateEntry {
         this.itemId = itemId;
         this.schedStartTime = pi.schedStart;
         this.schedEndTime = pi.schedEnd;
-        this.seqIds = [pi.preSectionIds, pi.mainSectionIds, pi.postSectionIds];
+        this.seqSections = [pi.preSection, pi.mainSection, pi.postSection];
         this.seqDurs = [pi.preSectionDurs, pi.mainSectionDurs, pi.postSectionDurs];
     }
 
@@ -669,7 +672,7 @@ class PlaybackStateEntry {
     item: PlaybackItem; // The expanded item, full instructions
     itemId: string = '';
 
-    seqIds: [string[], string[], string[]];
+    seqSections: [SequenceRecord[], SequenceRecord[], SequenceRecord[]];
     seqDurs: [number[], number[], number[]];
 
     // We make a lot of state transitions, one by one.  This means itemPart / itemCursor start at -1 and go to length
@@ -737,7 +740,7 @@ class PlaybackStateEntry {
             scheduleId: c.item.scheduleId,
             playlistId: c.item.playlistIds?.[c.itemPart],
             stackDepth: depth,
-            sequenceId: this.seqIds[c.itemPart]?.[c.itemCursor % (this.seqIds[c.itemPart].length || 1)],
+            sequenceId: this.seqSections[c.itemPart]?.[c.itemCursor % (this.seqSections[c.itemPart].length || 1)]?.id,
             entryIntoPlaylist: [c.itemPart, c.itemCursor],
             timeIntoSeqMS: c.offsetInto,
         });
@@ -748,12 +751,12 @@ class PlaybackStateEntry {
             this.addLog(depth, 'Sequence Ended', ctime, c, log);
         }
         ++c.itemCursor;
-        if (loop && c.itemCursor >= this.seqIds[c.itemPart].length) c.itemCursor = 0;
+        if (loop && c.itemCursor >= this.seqSections[c.itemPart].length) c.itemCursor = 0;
         c.offsetInto = 0;
     }
 
     endCurrentPart(depth: number, c: PlaybackCursor, ctime: number, log?: PlaybackLogDetail[]) {
-        if (c.itemPart >= 0 && c.itemPart <= 2 && this.seqIds[c.itemPart]?.length) {
+        if (c.itemPart >= 0 && c.itemPart <= 2 && this.seqSections[c.itemPart]?.length) {
             this.addLog(depth, 'Playlist Ended', ctime, c, log);
         }
         ++c.itemPart;
@@ -793,7 +796,7 @@ class PlaybackStateEntry {
         function startNextPart(ctime: number) {
             c.itemCursor = 0;
             c.offsetInto = 0;
-            if (c.itemPart <= 2 && pthis.seqIds[c.itemPart]?.length) {
+            if (c.itemPart <= 2 && pthis.seqSections[c.itemPart]?.length) {
                 pthis.addLog(depth, 'Playlist Started', ctime, c, log);
             }
         }
@@ -814,7 +817,7 @@ class PlaybackStateEntry {
             if (
                 c.itemPart >= 0 &&
                 c.itemPart <= 2 &&
-                (c.itemCursor >= this.seqIds[c.itemPart].length || c.endingPartEarly)
+                (c.itemCursor >= this.seqSections[c.itemPart].length || c.endingPartEarly)
             ) {
                 if (dbg) console.log('PSE endCurrentPart');
                 this.endCurrentPart(depth, c, curTime, log);
@@ -831,7 +834,7 @@ class PlaybackStateEntry {
             }
 
             // Do any trivial transitions, always
-            if (!this.seqIds[c.itemPart]?.length) {
+            if (!this.seqSections[c.itemPart]?.length) {
                 if (dbg) console.log('Trivial transition');
                 startNextPart(curTime);
                 this.endCurrentPart(depth, c, curTime, log);
@@ -871,7 +874,8 @@ class PlaybackStateEntry {
                     out?.push({
                         end: false,
                         atTime: curTime,
-                        seqId: c.item.preSectionIds[c.itemCursor],
+                        seqId: c.item.preSection[c.itemCursor]?.id,
+                        seq: c.item.preSection[c.itemCursor],
                         offsetMS: c.offsetInto,
                         durationMS: itime - c.offsetInto,
                     });
@@ -884,7 +888,8 @@ class PlaybackStateEntry {
                 out?.push({
                     end: false,
                     atTime: curTime,
-                    seqId: c.item.preSectionIds[c.itemCursor],
+                    seqId: c.item.preSection[c.itemCursor]?.id,
+                    seq: c.item.preSection[c.itemCursor],
                     offsetMS: c.offsetInto,
                     durationMS: itime - c.offsetInto,
                 });
@@ -911,7 +916,8 @@ class PlaybackStateEntry {
                     out?.push({
                         end: false,
                         atTime: curTime,
-                        seqId: c.item.mainSectionIds[c.itemCursor],
+                        seqId: c.item.mainSection[c.itemCursor]?.id,
+                        seq: c.item.mainSection[c.itemCursor],
                         offsetMS: c.offsetInto,
                         durationMS: itime - c.offsetInto,
                     });
@@ -952,7 +958,8 @@ class PlaybackStateEntry {
                         out?.push({
                             end: false,
                             atTime: curTime,
-                            seqId: c.item.mainSectionIds[c.itemCursor],
+                            seqId: c.item.mainSection[c.itemCursor]?.id,
+                            seq: c.item.mainSection[c.itemCursor],
                             offsetMS: c.offsetInto,
                             durationMS: shouldStartOutro,
                         });
@@ -965,7 +972,8 @@ class PlaybackStateEntry {
                             out?.push({
                                 end: false,
                                 atTime: curTime,
-                                seqId: c.item.mainSectionIds[c.itemCursor],
+                                seqId: c.item.mainSection[c.itemCursor]?.id,
+                                seq: c.item.mainSection[c.itemCursor],
                                 offsetMS: c.offsetInto,
                                 durationMS: useOutro,
                             });
@@ -988,7 +996,8 @@ class PlaybackStateEntry {
                 out?.push({
                     end: false,
                     atTime: curTime,
-                    seqId: c.item.postSectionIds[c.itemCursor],
+                    seqId: c.item.postSection[c.itemCursor]?.id,
+                    seq: c.item.postSection[c.itemCursor],
                     offsetMS: c.offsetInto,
                     durationMS: itime - c.offsetInto,
                 });
@@ -1176,13 +1185,19 @@ class PlaybackItem implements SchedulerHeapItem {
     scheduleId?: string = ''; // If this correlates to such
     playlistIds?: (string | undefined)[] = undefined; // If this correlates to such
 
-    preSectionIds: string[] = [];
+    // Each section holds the SequenceRecords for its positions, captured at populate
+    // time (the record carries its own id). Playback resolves detail (files, etc.)
+    // per position from here rather than the live master map, so an in-flight item is
+    // unaffected by later changes and each position can be reconciled on its own.
+    // Durations stay a separate array — their length drives loop math and, for
+    // shuffle, intentionally differs from the section length.
+    preSection: SequenceRecord[] = [];
     preSectionDurs: number[] = [];
     preSectionTotal: number = 0;
-    postSectionIds: string[] = [];
+    postSection: SequenceRecord[] = [];
     postSectionDurs: number[] = [];
     postSectionTotal: number = 0;
-    mainSectionIds: string[] = [];
+    mainSection: SequenceRecord[] = [];
     mainSectionDurs: number[] = [];
     mainSectionTotal: number = 0;
     mainSectionLongest: number = 0;
@@ -1370,6 +1385,17 @@ export class PlayerRunState {
         schedules: ScheduledPlaylist[],
         errs: string[],
     ) {
+        this.#setMasterData(seqs, playlists, schedules, errs);
+    }
+
+    /** Install sequence/playlist/schedule master data, replacing whatever is present.
+     *  Only the master arrays and maps are written; runtime state is not touched. */
+    #setMasterData(
+        seqs: SequenceRecord[],
+        playlists: PlaylistRecord[],
+        schedules: ScheduledPlaylist[],
+        errs: string[],
+    ) {
         this.sequences = seqs
             .filter((s) => s.deleted !== true)
             .map((s) => {
@@ -1389,8 +1415,48 @@ export class PlayerRunState {
             });
         this.schedules.sort((a, b) => getScheduleTimes(a).startTimeMS - getScheduleTimes(b).startTimeMS);
         this.schedulesById = scheduleToMap(this.schedules, errs, this.playlistsById);
+    }
 
-        // TODO CRAZ: If this is an update, go back the stack and update playing things if needed
+    /**
+     * Adopt updated sequence/playlist/schedule data into a running state. The master
+     * maps become current truth while all runtime state — stack, heap, upcoming
+     * occurrences, interactive queue, immediate item, stoppedIds — is preserved.
+     *
+     * Items already loaded carry their own captured sequence records (the per-position
+     * PlaybackItem section arrays), so in-flight playback is unaffected by the new
+     * data. Reconciling loaded occurrences to accepted changes — re-baking, dropping
+     * deleted entries, admitting new schedules — is handled per case on top of this.
+     */
+    applyDataUpdate(
+        seqs: SequenceRecord[],
+        playlists: PlaylistRecord[],
+        schedules: ScheduledPlaylist[],
+        errs: string[],
+    ) {
+        this.#setMasterData(seqs, playlists, schedules, errs);
+    }
+
+    /** File paths pinned by loaded playback items (stack, heap, upcoming), counted
+     *  from each item's captured sequence detail. Feeds old-file GC: a file present
+     *  here is still needed by something the player has loaded, even if its sequence
+     *  has since been changed or removed from the master data. */
+    referencedFileCounts(): Map<string, number> {
+        const counts = new Map<string, number>();
+        const add = (f?: string) => {
+            if (f) counts.set(f, (counts.get(f) ?? 0) + 1);
+        };
+        const addItem = (it: PlaybackItem) => {
+            for (const seq of [...it.preSection, ...it.mainSection, ...it.postSection]) {
+                add(seq.files?.fseq);
+                add(seq.files?.audio);
+                add(seq.files?.video);
+                add(seq.files?.thumb);
+            }
+        };
+        for (const e of this.stack) addItem(e.item);
+        for (const it of this.heapById.values()) addItem(it);
+        for (const it of this.upcomingOccurrences) addItem(it);
+        return counts;
     }
 
     #addToHeap(sc: PlaybackItem) {
@@ -1430,9 +1496,9 @@ export class PlayerRunState {
         sc.endPolicy = s.endPolicy;
         sc.keepToScheduleWhenPreempted = s.keepToScheduleWhenPreempted;
 
-        sc.preSectionIds = [];
+        sc.preSection = [];
         sc.preSectionTotal = 0;
-        sc.postSectionIds = [];
+        sc.postSection = [];
         sc.postSectionTotal = 0;
 
         const prepl = s.prePlaylistId ? this.playlistsById.get(s.prePlaylistId) : undefined;
@@ -1440,7 +1506,7 @@ export class PlayerRunState {
             for (let i = 0; i < prepl.items.length; ++i) {
                 const seq = this.sequencesById.get(prepl.items[i].id);
                 if (!seq) continue;
-                sc.preSectionIds.push(seq.id);
+                sc.preSection.push(seq);
                 const it = getSeqTimesMS(seq).totalSeqTimeMS || 1000;
                 sc.preSectionDurs.push(it);
                 sc.preSectionTotal += it;
@@ -1451,14 +1517,14 @@ export class PlayerRunState {
             for (let i = 0; i < postl.items.length; ++i) {
                 const seq = this.sequencesById.get(postl.items[i].id);
                 if (!seq) continue;
-                sc.postSectionIds.push(seq.id);
+                sc.postSection.push(seq);
                 const it = getSeqTimesMS(seq).totalSeqTimeMS || 1000;
                 sc.postSectionDurs.push(it);
                 sc.postSectionTotal += it;
             }
         }
 
-        sc.mainSectionIds = [];
+        sc.mainSection = [];
         sc.mainSectionLoop = !!(s.loop || s.shuffle);
         sc.mainSectionTotal = 0;
         sc.mainSectionLongest = 0;
@@ -1470,17 +1536,14 @@ export class PlayerRunState {
             sc.mainSectionLongest = mainTimes.longestMS;
 
             if (s.shuffle) {
-                sc.mainSectionIds = createShuffleList(
-                    mainpl,
-                    sc.schedStart,
-                    sc.schedEnd - sc.schedStart,
-                    this.sequencesById,
-                );
+                sc.mainSection = createShuffleList(mainpl, sc.schedStart, sc.schedEnd - sc.schedStart, this.sequencesById)
+                    .map((id) => this.sequencesById.get(id))
+                    .filter((seq): seq is SequenceRecord => !!seq);
             } else {
                 for (let i = 0; i < mainpl.items.length; ++i) {
                     const seq = this.sequencesById.get(mainpl.items[i].id);
                     if (!seq) continue;
-                    sc.mainSectionIds.push(seq.id);
+                    sc.mainSection.push(seq);
                     const it = getSeqTimesMS(seq).totalSeqTimeMS || 1000;
                     sc.mainSectionDurs.push(it);
                 }
@@ -1501,7 +1564,7 @@ export class PlayerRunState {
             sc.schedEnd = sc.schedStart + dur;
         } else if (ipc.playlistId) {
             sc.playlistIds = [undefined, ipc.playlistId, undefined];
-            sc.mainSectionIds = [];
+            sc.mainSection = [];
             sc.mainSectionLoop = false;
             sc.mainSectionTotal = 0;
             sc.mainSectionLongest = 0;
@@ -1515,21 +1578,21 @@ export class PlayerRunState {
                 for (let i = 0; i < mainpl.items.length; ++i) {
                     const seq = this.sequencesById.get(mainpl.items[i].id);
                     if (!seq) continue;
-                    sc.mainSectionIds.push(seq.id);
+                    sc.mainSection.push(seq);
                     const it = getSeqTimesMS(seq).totalSeqTimeMS || 1000;
                     sc.mainSectionDurs.push(it);
                 }
             }
         } else if (ipc.seqId) {
             sc.playlistIds = [undefined, undefined, undefined];
-            sc.mainSectionIds = [];
+            sc.mainSection = [];
             sc.mainSectionLoop = false;
             sc.mainSectionTotal = 0;
             sc.mainSectionLongest = 0;
 
             const seq = this.sequencesById.get(ipc.seqId);
             if (seq) {
-                sc.mainSectionIds.push(seq.id);
+                sc.mainSection.push(seq);
                 const it = getSeqTimesMS(seq).totalSeqTimeMS || 1000;
                 sc.mainSectionDurs.push(it);
                 sc.mainSectionTotal = it;
@@ -1600,6 +1663,11 @@ export class PlayerRunState {
 
     get depth() {
         return this.stack.length;
+    }
+
+    /** True when there is live, imminent, or queued playback that a rebuild would disrupt. */
+    get isPlaying() {
+        return this.stack.length > 0 || !!this.immediateItem || this.interactiveQueue.length > 0;
     }
 
     // Read the schedule out...
@@ -1927,7 +1995,7 @@ export class PlayerRunState {
                 scheduleId: s.item.scheduleId,
                 itemId: s.item.itemId,
                 playlistNumber: spl,
-                playlistIds: s.seqIds[spl] ?? [],
+                playlistIds: (s.seqSections[spl] ?? []).map((x) => x.id),
                 playlistDurations: s.seqDurs[spl] ?? [],
                 seqIdx: spi,
                 offsetInto: s.offsetInto,
@@ -2147,7 +2215,7 @@ export class PlayerRunState {
 
         // If a songId was specified, only skip if it matches the current sequence
         if (songId !== undefined) {
-            const curSeqId = st.seqIds[st.itemPart]?.[st.itemCursor % (st.seqIds[st.itemPart].length || 1)];
+            const curSeqId = st.seqSections[st.itemPart]?.[st.itemCursor % (st.seqSections[st.itemPart].length || 1)]?.id;
             if (curSeqId !== songId) return;
         }
 
@@ -2208,13 +2276,13 @@ export class PlayerRunState {
                     request_id: s.requestId,
                     title: this.titleForIds(undefined, s.playlistIds?.[1], undefined),
                 } as PlayingItem);
-            } else if (s.mainSectionIds?.[0]) {
+            } else if (s.mainSection?.[0]) {
                 items.push({
                     type: s.itemType,
                     item: 'Song',
-                    sequence_id: s.mainSectionIds[0],
+                    sequence_id: s.mainSection[0].id,
                     request_id: s.requestId,
-                    title: this.titleForIds(s.mainSectionIds[0], undefined, undefined),
+                    title: this.titleForIds(s.mainSection[0].id, undefined, undefined),
                 } as PlayingItem);
             }
         }
@@ -2259,13 +2327,13 @@ export class PlayerRunState {
                     request_id: s.requestId,
                     title: this.titleForIds(undefined, s.playlistIds?.[1], undefined),
                 } as PlayingItem);
-            } else if (s.mainSectionIds?.[0]) {
+            } else if (s.mainSection?.[0]) {
                 items.push({
                     type: 'Immediate',
                     item: 'Song',
-                    sequence_id: s.mainSectionIds[0],
+                    sequence_id: s.mainSection[0].id,
                     request_id: s.requestId,
-                    title: this.titleForIds(s.mainSectionIds[0], undefined, undefined),
+                    title: this.titleForIds(s.mainSection[0].id, undefined, undefined),
                 } as PlayingItem);
             }
         }

--- a/packages/ezplayer-core/tests/applyDataUpdate.test.ts
+++ b/packages/ezplayer-core/tests/applyDataUpdate.test.ts
@@ -221,4 +221,39 @@ describe('applyDataUpdate', () => {
 
         expect(plr.interactiveQueue.map((q) => q.requestId)).toEqual(['keep']);
     });
+
+    it('accepts an end-time change to the active schedule', () => {
+        const plr = runningState();
+        const top = plr.stack[plr.stack.length - 1];
+        expect(top.item.schedEnd).toBe(baseTime() + 19 * 3600_000);
+
+        const extended: ScheduledPlaylist = { ...sched, toTime: '20:00' };
+        apply(plr, [seqA, seqB, seqC], [plAB], [extended]);
+
+        expect(top.item.schedEnd).toBe(baseTime() + 20 * 3600_000);
+        expect(plr.depth).toBeGreaterThan(0); // still playing
+    });
+
+    it('winds down an active schedule that was deleted', () => {
+        const plr = runningState();
+        const top = plr.stack[plr.stack.length - 1];
+
+        apply(plr, [seqA, seqB, seqC], [plAB], []); // schedule deleted
+
+        expect(top.item.schedEnd).toBeLessThanOrEqual(plr.currentTime);
+        plr.runUntil(plr.currentTime + 3600_000); // it ends as the player advances
+        expect(plr.depth).toBe(0);
+    });
+
+    it('leaves the active schedule frozen when the start time moved', () => {
+        const plr = runningState();
+        const top = plr.stack[plr.stack.length - 1];
+
+        // Both start and end changed; because the start moved, nothing is accepted.
+        const moved: ScheduledPlaylist = { ...sched, fromTime: '17:00', toTime: '20:00' };
+        apply(plr, [seqA, seqB, seqC], [plAB], [moved]);
+
+        expect(top.item.schedStart).toBe(baseTime() + 18 * 3600_000); // unchanged
+        expect(top.item.schedEnd).toBe(baseTime() + 19 * 3600_000); // unchanged
+    });
 });

--- a/packages/ezplayer-core/tests/applyDataUpdate.test.ts
+++ b/packages/ezplayer-core/tests/applyDataUpdate.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+
+import { PlaylistRecord, ScheduledPlaylist, SequenceRecord } from '../src/types/DataTypes';
+import { PlayerRunState } from '../src/util/schedulecomp';
+
+// Two sequences that play (A then B), one that is merely present (C), exercised by a
+// single one-hour schedule. applyDataUpdate folds new data into a RUNNING state; these
+// tests pin the v0 nondisruptive guarantees.
+
+const seqA: SequenceRecord = {
+    id: 'A',
+    instanceId: 'A',
+    work: { length: 100, artist: 'a', title: 'A' },
+    files: { fseq: 'a.fseq', audio: 'a.mp3' },
+};
+const seqB: SequenceRecord = {
+    id: 'B',
+    instanceId: 'B',
+    work: { length: 100, artist: 'b', title: 'B' },
+    files: { fseq: 'b.fseq', audio: 'b.mp3' },
+};
+const seqC: SequenceRecord = { id: 'C', instanceId: 'C', work: { length: 100, artist: 'c', title: 'C' } };
+
+const plAB: PlaylistRecord = {
+    id: 'plAB',
+    title: 'plAB',
+    tags: [],
+    createdAt: 0,
+    items: [
+        { id: 'A', sequence: 1 },
+        { id: 'B', sequence: 2 },
+    ],
+};
+
+const sched: ScheduledPlaylist = {
+    id: 'sched',
+    scheduleType: 'main',
+    title: 'sched',
+    playlistId: 'plAB',
+    playlistTitle: 'plAB',
+    date: 0,
+    fromTime: '18:00',
+    toTime: '19:00',
+    duration: 0,
+};
+
+function baseTime(): number {
+    const d = new Date(sched.date);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+}
+
+/** Build a state already mid-playback: 10s into the 18:00 schedule, so seqA is on
+ *  the active stack. Returns the run state and the moment it was advanced to. */
+function runningState(): PlayerRunState {
+    const bt = baseTime();
+    const plr = new PlayerRunState(bt);
+    const errs: string[] = [];
+    plr.setUpSequences([seqA, seqB, seqC], [plAB], [sched], errs);
+    expect(errs).toEqual([]);
+    plr.addTimeRangeToSchedule(bt, bt + 24 * 3600_000); // load the day's occurrences
+    plr.runUntil(bt + 18 * 3600_000 + 10_000); // 10s into the schedule
+    expect(plr.depth).toBeGreaterThan(0); // something is actually playing
+    return plr;
+}
+
+describe('isPlaying', () => {
+    it('is false for an idle state and true for live, immediate, or queued playback', () => {
+        const idle = new PlayerRunState(0);
+        expect(idle.isPlaying).toBe(false);
+
+        idle.interactiveQueue.push({ immediate: false, startTime: 0, seqId: 'A', requestId: 'q' });
+        expect(idle.isPlaying).toBe(true);
+
+        const imm = new PlayerRunState(0);
+        imm.immediateItem = { immediate: true, startTime: 0, seqId: 'A', requestId: 'imm' };
+        expect(imm.isPlaying).toBe(true);
+
+        expect(runningState().isPlaying).toBe(true); // non-empty stack
+    });
+});
+
+describe('applyDataUpdate', () => {
+    it('leaves the active stack object untouched (no rebuild)', () => {
+        const plr = runningState();
+        const stackBefore = plr.stack;
+        const topBefore = plr.stack[plr.stack.length - 1];
+
+        plr.applyDataUpdate([seqA, seqB, seqC], [plAB], [sched], []);
+
+        expect(plr.stack).toBe(stackBefore); // same array, not rebuilt
+        expect(plr.stack[plr.stack.length - 1]).toBe(topBefore); // same entry
+    });
+
+    it('preserves the interactive queue, immediate item, and stoppedIds', () => {
+        const plr = runningState();
+        plr.interactiveQueue.push({ immediate: false, startTime: 0, seqId: 'C', requestId: 'q1' });
+        plr.immediateItem = { immediate: true, startTime: 0, seqId: 'C', requestId: 'imm' };
+        plr.stoppedIds.set('someSched', 999);
+
+        plr.applyDataUpdate([seqA, seqB, seqC], [plAB], [sched], []);
+
+        expect(plr.interactiveQueue.map((q) => q.requestId)).toEqual(['q1']);
+        expect(plr.immediateItem?.requestId).toBe('imm');
+        expect(plr.stoppedIds.get('someSched')).toBe(999);
+    });
+
+    it('keeps a playing sequence on its captured detail while the master map updates', () => {
+        const plr = runningState();
+        const editedA: SequenceRecord = { ...seqA, work: { ...seqA.work, length: 999 } };
+
+        plr.applyDataUpdate([editedA, seqB, seqC], [plAB], [sched], []);
+
+        // The master map is now current truth.
+        expect(plr.sequencesById.get('A')?.work.length).toBe(999);
+        // The in-flight item keeps the record captured when it started.
+        const top = plr.stack[plr.stack.length - 1];
+        expect(top.item.mainSection[0]?.work.length).toBe(100);
+        // The action handed to the renderer carries that captured record.
+        const action = plr.getUpcomingItems(60_000, 24 * 3600_000).curPLActions?.actions?.[0];
+        expect(action?.seqId).toBe('A');
+        expect(action?.seq?.work.length).toBe(100);
+    });
+
+    it('keeps a deleted-while-playing sequence resolvable for the renderer', () => {
+        const plr = runningState();
+
+        // seqA omitted entirely from the new data (deleted/disabled upstream).
+        plr.applyDataUpdate([seqB, seqC], [plAB], [sched], []);
+
+        // Master map reflects the deletion...
+        expect(plr.sequencesById.has('A')).toBe(false);
+        // ...but the playing item still resolves it, so playback continues.
+        const action = plr.getUpcomingItems(60_000, 24 * 3600_000).curPLActions?.actions?.[0];
+        expect(action?.seqId).toBe('A');
+        expect(action?.seq?.work.length).toBe(100);
+    });
+
+    it('adopts new details for sequences that are not on the active stack', () => {
+        const plr = runningState();
+        const editedC: SequenceRecord = { ...seqC, work: { ...seqC.work, length: 42 } };
+        const seqD: SequenceRecord = { id: 'D', instanceId: 'D', work: { length: 7, artist: 'd', title: 'D' } };
+
+        plr.applyDataUpdate([seqA, seqB, editedC, seqD], [plAB], [sched], []);
+
+        expect(plr.sequencesById.get('C')?.work.length).toBe(42); // updated (not playing)
+        expect(plr.sequencesById.has('D')).toBe(true); // newly added song present
+    });
+
+    it('pins files of loaded items for GC, even after the sequence is removed upstream', () => {
+        const plr = runningState();
+        expect(plr.referencedFileCounts().get('a.fseq')).toBeGreaterThanOrEqual(1);
+
+        // seqA deleted upstream, but it is still on the active stack.
+        plr.applyDataUpdate([seqB, seqC], [plAB], [sched], []);
+
+        expect(plr.sequencesById.has('A')).toBe(false); // gone from current truth
+        expect(plr.referencedFileCounts().get('a.fseq')).toBeGreaterThanOrEqual(1); // still pinned
+    });
+});

--- a/packages/ezplayer-core/tests/applyDataUpdate.test.ts
+++ b/packages/ezplayer-core/tests/applyDataUpdate.test.ts
@@ -44,24 +44,49 @@ const sched: ScheduledPlaylist = {
     duration: 0,
 };
 
+// A second schedule later the same day — future relative to the running state below,
+// so it lands in upcoming rather than on the stack.
+const sched2: ScheduledPlaylist = {
+    id: 'sched2',
+    scheduleType: 'main',
+    title: 'sched2',
+    playlistId: 'plAB',
+    playlistTitle: 'plAB',
+    date: 0,
+    fromTime: '20:00',
+    toTime: '21:00',
+    duration: 0,
+};
+
 function baseTime(): number {
     const d = new Date(sched.date);
     d.setHours(0, 0, 0, 0);
     return d.getTime();
 }
 
+const DAY = 24 * 3600_000;
+
 /** Build a state already mid-playback: 10s into the 18:00 schedule, so seqA is on
- *  the active stack. Returns the run state and the moment it was advanced to. */
-function runningState(): PlayerRunState {
+ *  the active stack and any later schedule sits in upcoming. */
+function runningStateWith(schedules: ScheduledPlaylist[]): PlayerRunState {
     const bt = baseTime();
     const plr = new PlayerRunState(bt);
     const errs: string[] = [];
-    plr.setUpSequences([seqA, seqB, seqC], [plAB], [sched], errs);
+    plr.setUpSequences([seqA, seqB, seqC], [plAB], schedules, errs);
     expect(errs).toEqual([]);
-    plr.addTimeRangeToSchedule(bt, bt + 24 * 3600_000); // load the day's occurrences
+    plr.addTimeRangeToSchedule(bt, bt + DAY); // load the day's occurrences
     plr.runUntil(bt + 18 * 3600_000 + 10_000); // 10s into the schedule
     expect(plr.depth).toBeGreaterThan(0); // something is actually playing
     return plr;
+}
+
+function runningState(): PlayerRunState {
+    return runningStateWith([sched]);
+}
+
+/** Reconcile, refilling the rest of the loaded day. */
+function apply(plr: PlayerRunState, seqs: SequenceRecord[], pls: PlaylistRecord[], sch: ScheduledPlaylist[]) {
+    plr.applyDataUpdate(seqs, pls, sch, [], plr.currentTime, baseTime() + DAY);
 }
 
 describe('isPlaying', () => {
@@ -86,7 +111,7 @@ describe('applyDataUpdate', () => {
         const stackBefore = plr.stack;
         const topBefore = plr.stack[plr.stack.length - 1];
 
-        plr.applyDataUpdate([seqA, seqB, seqC], [plAB], [sched], []);
+        apply(plr, [seqA, seqB, seqC], [plAB], [sched]);
 
         expect(plr.stack).toBe(stackBefore); // same array, not rebuilt
         expect(plr.stack[plr.stack.length - 1]).toBe(topBefore); // same entry
@@ -96,20 +121,21 @@ describe('applyDataUpdate', () => {
         const plr = runningState();
         plr.interactiveQueue.push({ immediate: false, startTime: 0, seqId: 'C', requestId: 'q1' });
         plr.immediateItem = { immediate: true, startTime: 0, seqId: 'C', requestId: 'imm' };
-        plr.stoppedIds.set('someSched', 999);
+        const stopUntil = baseTime() + 19 * 3600_000; // future, so not pruned by refill
+        plr.stoppedIds.set('someSched', stopUntil);
 
-        plr.applyDataUpdate([seqA, seqB, seqC], [plAB], [sched], []);
+        apply(plr, [seqA, seqB, seqC], [plAB], [sched]);
 
         expect(plr.interactiveQueue.map((q) => q.requestId)).toEqual(['q1']);
         expect(plr.immediateItem?.requestId).toBe('imm');
-        expect(plr.stoppedIds.get('someSched')).toBe(999);
+        expect(plr.stoppedIds.get('someSched')).toBe(stopUntil);
     });
 
     it('keeps a playing sequence on its captured detail while the master map updates', () => {
         const plr = runningState();
         const editedA: SequenceRecord = { ...seqA, work: { ...seqA.work, length: 999 } };
 
-        plr.applyDataUpdate([editedA, seqB, seqC], [plAB], [sched], []);
+        apply(plr, [editedA, seqB, seqC], [plAB], [sched]);
 
         // The master map is now current truth.
         expect(plr.sequencesById.get('A')?.work.length).toBe(999);
@@ -126,7 +152,7 @@ describe('applyDataUpdate', () => {
         const plr = runningState();
 
         // seqA omitted entirely from the new data (deleted/disabled upstream).
-        plr.applyDataUpdate([seqB, seqC], [plAB], [sched], []);
+        apply(plr, [seqB, seqC], [plAB], [sched]);
 
         // Master map reflects the deletion...
         expect(plr.sequencesById.has('A')).toBe(false);
@@ -141,7 +167,7 @@ describe('applyDataUpdate', () => {
         const editedC: SequenceRecord = { ...seqC, work: { ...seqC.work, length: 42 } };
         const seqD: SequenceRecord = { id: 'D', instanceId: 'D', work: { length: 7, artist: 'd', title: 'D' } };
 
-        plr.applyDataUpdate([seqA, seqB, editedC, seqD], [plAB], [sched], []);
+        apply(plr, [seqA, seqB, editedC, seqD], [plAB], [sched]);
 
         expect(plr.sequencesById.get('C')?.work.length).toBe(42); // updated (not playing)
         expect(plr.sequencesById.has('D')).toBe(true); // newly added song present
@@ -152,9 +178,47 @@ describe('applyDataUpdate', () => {
         expect(plr.referencedFileCounts().get('a.fseq')).toBeGreaterThanOrEqual(1);
 
         // seqA deleted upstream, but it is still on the active stack.
-        plr.applyDataUpdate([seqB, seqC], [plAB], [sched], []);
+        apply(plr, [seqB, seqC], [plAB], [sched]);
 
         expect(plr.sequencesById.has('A')).toBe(false); // gone from current truth
         expect(plr.referencedFileCounts().get('a.fseq')).toBeGreaterThanOrEqual(1); // still pinned
+    });
+
+    it('admits a newly added schedule into the rebuilt upcoming', () => {
+        const plr = runningState();
+        expect(plr.upcomingById.has('sched2')).toBe(false);
+
+        apply(plr, [seqA, seqB, seqC], [plAB], [sched, sched2]);
+
+        expect(plr.upcomingById.has('sched2')).toBe(true);
+    });
+
+    it('drops a deleted future schedule from the rebuilt upcoming', () => {
+        const plr = runningStateWith([sched, sched2]);
+        expect(plr.upcomingById.has('sched2')).toBe(true);
+
+        apply(plr, [seqA, seqB, seqC], [plAB], [sched]);
+
+        expect(plr.upcomingById.has('sched2')).toBe(false);
+    });
+
+    it('rebuilds an upcoming occurrence from the edited playlist', () => {
+        const plr = runningStateWith([sched, sched2]);
+        expect(plr.upcomingById.get('sched2')?.mainSection.map((s) => s.id)).toEqual(['A', 'B']);
+
+        const plJustA: PlaylistRecord = { ...plAB, items: [{ id: 'A', sequence: 1 }] };
+        apply(plr, [seqA, seqB, seqC], [plJustA], [sched, sched2]);
+
+        expect(plr.upcomingById.get('sched2')?.mainSection.map((s) => s.id)).toEqual(['A']);
+    });
+
+    it('drops an interactive request whose target no longer exists', () => {
+        const plr = runningState();
+        plr.interactiveQueue.push({ immediate: false, startTime: 0, seqId: 'B', requestId: 'keep' });
+        plr.interactiveQueue.push({ immediate: false, startTime: 0, seqId: 'C', requestId: 'drop' });
+
+        apply(plr, [seqA, seqB], [plAB], [sched]); // seqC removed upstream
+
+        expect(plr.interactiveQueue.map((q) => q.requestId)).toEqual(['keep']);
     });
 });


### PR DESCRIPTION
When schedules, playlists, and songs are added/updated/removed, this was restarting the schedule.  With this PR, most things are captured when the schedule starts playing, allowing changes to be made without disruption (if you want a disruption, hit the restart button).

Follow-on enhancement request #130 

Fixes #53 

