### PR TITLE
Trade show, mini, and other fixes

### DIFF
--- a/apps/ezplayer-ui-electron/main.ts
+++ b/apps/ezplayer-ui-electron/main.ts
@@ -125,6 +125,8 @@ const createWindow = (showFolder?: string, showWelcomeOnLaunch?: boolean) => {
             preload: path.join(__dirname, 'preload-audio.js'),
             contextIsolation: true,
             webSecurity: false,
+            // Hidden window default-throttles audio render; keep it full-priority.
+            backgroundThrottling: false,
         },
     });
 

--- a/apps/ezplayer-ui-electron/mainsrc/data/atomicWrite.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/data/atomicWrite.ts
@@ -1,6 +1,24 @@
 import fs from 'fs/promises';
 import path from 'path';
 
+/** Bounded retry around `fs.rename` for Windows AV-scan races. */
+async function renameWithRetry(src: string, dst: string): Promise<void> {
+    const delays = [25, 50, 100, 200, 400];
+    let lastErr: unknown;
+    for (let i = 0; i <= delays.length; i++) {
+        try {
+            await fs.rename(src, dst);
+            return;
+        } catch (err) {
+            const code = (err as { code?: string }).code;
+            if (code !== 'EPERM' && code !== 'EBUSY' && code !== 'EACCES') throw err;
+            lastErr = err;
+            if (i < delays.length) await new Promise((r) => setTimeout(r, delays[i]));
+        }
+    }
+    throw lastErr;
+}
+
 /**
  * Crash-safe write: stage to a sibling temp file, fsync, then rename over the
  * target. Avoids the 0-byte window of a plain `writeFile` with `O_TRUNC`.
@@ -50,7 +68,7 @@ export async function atomicWriteFile(
         await handle.close();
         handle = undefined;
 
-        await fs.rename(tmpPath, targetPath);
+        await renameWithRetry(tmpPath, targetPath);
     } catch (err) {
         // Best-effort cleanup of the temp file if anything went wrong before
         // (or during) the rename. Swallow ENOENT — the temp may not exist yet.

--- a/apps/ezplayer-ui-electron/mainsrc/ipcezplayer.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/ipcezplayer.ts
@@ -403,8 +403,17 @@ let lastAppliedCloudCfg: CloudConfig | undefined;
 
 /** Common sequence-upsert path used by both the renderer-driven IPC and the cloud
  *  content sync. Runs `mergeSequences`, persists, broadcasts to renderer + WS, kicks
- *  the playback worker, and refreshes the cloud worker's local-sequences cache. */
+ *  the playback worker, and refreshes the cloud worker's local-sequences cache.
+ *  Serialized: cloud-install events can fire several records in quick succession,
+ *  and concurrent commits would race on the same `sequences.json` (Windows
+ *  EPERM on rename, plus a merge-against-stale-curSequences silent record loss). */
+let commitChain: Promise<unknown> = Promise.resolve();
 async function commitSequenceUpdates(uppl: SequenceRecord[]): Promise<SequenceRecord[]> {
+    const next = commitChain.then(() => commitSequenceUpdatesInner(uppl));
+    commitChain = next.catch(() => {});
+    return next;
+}
+async function commitSequenceUpdatesInner(uppl: SequenceRecord[]): Promise<SequenceRecord[]> {
     const showFolder = getCurrentShowFolder();
     const updList = mergeSequences(uppl, curSequences ?? []);
     if (showFolder) {

--- a/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
@@ -39,6 +39,12 @@ import { FSEQReaderAsync } from '@ezplayer/epp';
 const DEFAULT_REGISTRATION_INTERVAL_MS = 5_000;
 const DEFAULT_MANIFEST_INTERVAL_MS = 300_000;
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
+/** Cap on the JSON-poll fetches (registration heartbeat, manifest list,
+ *  playlists, schedule, settings). Without a timeout, a hung TCP socket
+ *  parks `regInFlight` / `manifestInFlight` true forever — observed once as a
+ *  player stuck on "waiting for registration" even though the cloud had
+ *  already registered the token, fixable only by restarting the player. */
+const DEFAULT_POLL_TIMEOUT_MS = 15_000;
 const DEFAULT_FAILURE_THRESHOLD = 5;
 
 let cloudUrl = '';
@@ -356,7 +362,7 @@ async function pollRegistration() {
         ...(lastContentSyncAt !== undefined ? { lastContentSync: lastContentSyncAt } : {}),
     };
     try {
-        const res = await fetch(url, {
+        const res = await fetchWithTimeout(url, DEFAULT_POLL_TIMEOUT_MS, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify(body),
@@ -459,7 +465,7 @@ async function pollManifest() {
     const url = `${cloudUrl}${CLOUD_API_ENDPOINTS.EZP_GET_SEQ_LIST}${playerIdToken}`;
     log('info', `manifest poll ${url}`);
     try {
-        const res = await fetch(url, { method: 'GET' });
+        const res = await fetchWithTimeout(url, DEFAULT_POLL_TIMEOUT_MS, { method: 'GET' });
         if (!res.ok) {
             recordFailure(`manifest HTTP ${res.status}`);
             return;
@@ -487,7 +493,7 @@ async function fetchPlaylistsAndSchedule() {
     if (!cloudUrl || !playerIdToken) return;
     const plUrl = `${cloudUrl}${CLOUD_API_ENDPOINTS.EZP_GET_PLAYLISTS}${playerIdToken}`;
     try {
-        const res = await fetch(plUrl, { method: 'GET' });
+        const res = await fetchWithTimeout(plUrl, DEFAULT_POLL_TIMEOUT_MS, { method: 'GET' });
         if (res.ok) {
             const body = (await res.json()) as { playlists?: PlaylistRecord[] };
             const playlists = body.playlists ?? [];
@@ -506,7 +512,7 @@ async function fetchPlaylistsAndSchedule() {
 
     const schUrl = `${cloudUrl}${CLOUD_API_ENDPOINTS.EZP_GET_SCHEDULE}${playerIdToken}`;
     try {
-        const res = await fetch(schUrl, { method: 'GET' });
+        const res = await fetchWithTimeout(schUrl, DEFAULT_POLL_TIMEOUT_MS, { method: 'GET' });
         if (res.ok) {
             const body = (await res.json()) as { schedule?: ScheduledPlaylist[] };
             const schedule = body.schedule ?? [];
@@ -532,7 +538,7 @@ async function fetchPlayerSettings() {
     if (!cloudUrl || !playerIdToken) return;
     const url = `${cloudUrl}${CLOUD_API_ENDPOINTS.EZP_GET_SETTINGS}${playerIdToken}`;
     try {
-        const res = await fetch(url, { method: 'GET' });
+        const res = await fetchWithTimeout(url, DEFAULT_POLL_TIMEOUT_MS, { method: 'GET' });
         if (!res.ok) {
             log('warn', `settings HTTP ${res.status}`);
             return;

--- a/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
@@ -1139,6 +1139,9 @@ async function buildSequenceRecord(
     const next: SequenceRecord = {
         ...(existing ?? { instanceId: randomUUID(), id: entry.id, work: { title: '', artist: '', length: 0 } }),
         id: entry.id,
+        // Clear tombstone flags from a prior disabled/pending pass.
+        render_enabled: true,
+        deleted: false,
         work: {
             ...(existing?.work ?? { title: '', artist: '', length: 0 }),
             title: entry.title ?? existing?.work?.title ?? '',

--- a/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/cloudpoll.ts
@@ -677,7 +677,13 @@ async function reconcileManifest(manifest: CloudSeqManifestEntry[]) {
         const fileIds: string[] = [];
         const pending: PendingFile[] = [];
 
-        if (entry.status === 'disabled') {
+        if (entry.status === 'disabled' || entry.status === 'pending') {
+            // Same on-record shape for both: a tombstone SequenceRecord with
+            // render_enabled=false hides it from jukebox/playlist/songs/
+            // schedule. The CloudSequenceProgress carries the distinguishing
+            // flag (`disabled` vs `pending`) so the cloud panel can label
+            // why — important for the curious operator watching a granted
+            // sequence not yet show up because render is still queued.
             const record = buildDisabledSequenceRecord(entry, existing);
             post({ type: 'installSequence', record });
             const idx = existingSequences.findIndex((s) => s.id === record.id);
@@ -689,7 +695,7 @@ async function reconcileManifest(manifest: CloudSeqManifestEntry[]) {
                 artist: entry.artist || '',
                 vendor: entry.vendor,
                 fileIds: [],
-                disabled: true,
+                ...(entry.status === 'disabled' ? { disabled: true } : { pending: true }),
             };
             perEntryPending.set(entry.id, []);
             continue;

--- a/apps/ezplayer-ui-electron/package.json
+++ b/apps/ezplayer-ui-electron/package.json
@@ -5,7 +5,7 @@
         "url": "https://github.com/ezpixelplayer/ezplayer.git"
     },
     "private": true,
-    "version": "0.4.3",
+    "version": "0.4.4",
     "main": "dist/main.js",
     "type": "module",
     "build": {

--- a/apps/ezplayer-ui-embedded/package.json
+++ b/apps/ezplayer-ui-embedded/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ezplayer/ui-embedded",
     "private": true,
-    "version": "0.4.3",
+    "version": "0.4.4",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ezplayer/ezplayer",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "private": true,
     "type": "module",
     "repository": {

--- a/packages/ezplayer-core/package.json
+++ b/packages/ezplayer-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ezplayer/ezplayer-core",
     "private": true,
-    "version": "0.3.6",
+    "version": "0.3.7",
     "sideEffects": false,
     "files": [
         "dist"

--- a/packages/ezplayer-core/src/index.ts
+++ b/packages/ezplayer-core/src/index.ts
@@ -87,6 +87,8 @@ export { CLOUD_API_ENDPOINTS } from './constants/CloudApiEndpoints';
 
 export { mergePlaylists, mergeSchedule, mergeSequences } from './util/Mergers';
 
+export { isSequencePlayable } from './util/seqFilter';
+
 export {
     type PlayAction,
     type PlaybackActions,

--- a/packages/ezplayer-core/src/types/DataTypes.ts
+++ b/packages/ezplayer-core/src/types/DataTypes.ts
@@ -225,8 +225,13 @@ export interface CloudSeqManifestEntry {
      *    unavailable so the playback engine drops it at bake time, and lets
      *    its file-sweep reclaim the on-disk files once no baked state
      *    references them.
+     *  - `pending`: grant is live but the render hasn't produced a playable
+     *    file yet (still in the render queue). Identity-only payload (no file
+     *    refs). Player surfaces it on the cloud panel as "rendering" for
+     *    visibility but treats it like `disabled` for playback gating, so
+     *    the jukebox never offers a song that can't play.
      *  Absent value treated as `active` for back-compat. */
-    status?: 'active' | 'disabled';
+    status?: 'active' | 'disabled' | 'pending';
 }
 
 /** Per-sequence projection of the in-flight cloud sync. The UI rolls up status
@@ -240,6 +245,10 @@ export interface CloudSequenceProgress {
     fileIds: string[];
     /** Cloud said disabled — no files; GC sweep reclaims on next pass. */
     disabled?: boolean;
+    /** Cloud said render hasn't produced a playable file yet (no fseq). UI
+     *  surfaces this as "rendering" so the operator can see why a granted
+     *  sequence isn't in the jukebox yet. */
+    pending?: boolean;
 }
 
 /** Per-file status used by the cloud content sync. */

--- a/packages/ezplayer-core/src/util/schedulecomp.ts
+++ b/packages/ezplayer-core/src/util/schedulecomp.ts
@@ -5,6 +5,7 @@ import type {
     ScheduleEndPolicy,
     SequenceRecord,
 } from '../types/DataTypes';
+import { isSequencePlayable } from './seqFilter';
 
 // Module goals:
 //   Deep understanding of the schedule - simulate a run
@@ -1392,7 +1393,7 @@ export class PlayerRunState {
         errs: string[],
     ) {
         this.sequences = seqs
-            .filter((s) => s.deleted !== true && s.render_enabled !== false)
+            .filter(isSequencePlayable)
             .map((s) => {
                 return { ...s };
             });

--- a/packages/ezplayer-core/src/util/seqFilter.ts
+++ b/packages/ezplayer-core/src/util/seqFilter.ts
@@ -1,0 +1,24 @@
+/** Just the fields `isSequencePlayable` reads — a structural subset of
+ *  `SequenceRecord` so callers with leaner local types (e.g. `SequenceItem`
+ *  inside `JukeboxScreen`) don't need a cast at every call site. */
+export interface PlayableSequenceFields {
+    deleted?: boolean;
+    render_enabled?: boolean;
+    files?: { fseq?: string };
+}
+
+/** Single source of truth for "is this sequence offerable to the user as a
+ *  playable song." All UI surfaces (jukebox, playlist builder, song list,
+ *  schedule baker) MUST use this — every condition added here updates them
+ *  all at once.
+ *
+ *  Conditions, in order of cheapness:
+ *  - not soft-deleted
+ *  - render_enabled !== false (cloud-side master toggle, mirrored on the record)
+ *  - has a real fseq file path (i.e. render has produced a playable artifact). */
+export function isSequencePlayable(s: PlayableSequenceFields): boolean {
+    if (s.deleted) return false;
+    if (s.render_enabled === false) return false;
+    if (!s.files?.fseq) return false;
+    return true;
+}

--- a/packages/player-ui-components/src/components/cloud/CloudPage.tsx
+++ b/packages/player-ui-components/src/components/cloud/CloudPage.tsx
@@ -79,7 +79,7 @@ const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => 
     </Box>
 );
 
-type RolledUpStatus = 'known' | 'downloading' | 'pending' | 'installed' | 'error' | 'disabled';
+type RolledUpStatus = 'known' | 'downloading' | 'pending' | 'installed' | 'error' | 'disabled' | 'rendering';
 
 const STATUS_COLOR: Record<RolledUpStatus | CloudFileStatus, 'default' | 'info' | 'warning' | 'success' | 'error'> = {
     known: 'default',
@@ -89,9 +89,15 @@ const STATUS_COLOR: Record<RolledUpStatus | CloudFileStatus, 'default' | 'info' 
     installed: 'success',
     error: 'error',
     disabled: 'warning',
+    rendering: 'info',
 };
 
 function rollUpStatus(seq: CloudSequenceProgress, files: CloudFileEntry[]): RolledUpStatus {
+    // `rendering` precedes `disabled` because a pending tombstone has no
+    // file refs (files.length === 0) — without this check, an operator
+    // watching a granted-but-queued sequence would see "known" and not
+    // realize the cloud is still preparing it.
+    if (seq.pending) return 'rendering';
     if (seq.disabled) return 'disabled';
     if (files.length === 0) return 'known';
     if (files.some((f) => f.status === 'error')) return 'error';

--- a/packages/player-ui-components/src/components/cloud/CloudPage.tsx
+++ b/packages/player-ui-components/src/components/cloud/CloudPage.tsx
@@ -47,6 +47,11 @@ import type { CloudFileEntry, CloudFileStatus, CloudSequenceProgress } from '@ez
 interface CloudPageProps {
     title: string;
     statusArea?: React.ReactNode[];
+    /** When false, hides Register / Disconnect / Edit-token controls. Used
+     *  when the page is hosted in a context where the player token came in
+     *  externally (e.g. embedded in the URL) — those buttons would invalidate
+     *  the host's own session. Defaults to true. */
+    allowRegistration?: boolean;
 }
 
 const formatTimestamp = (ms?: number) => {
@@ -250,7 +255,7 @@ const SequenceRow: React.FC<{
     );
 };
 
-export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
+export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea, allowRegistration = true }) => {
     const cloudConfig = useSelector((s: RootState) => s.cloudConfig);
     const cloudStatus = useSelector((s: RootState) => s.cloudStatus);
     const cStatus = useSelector((s: RootState) => s.runtime.combined.content);
@@ -467,8 +472,10 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                         {modeDescription}
                     </Typography>
 
-                    {/* Mode 1: not registered → just Register. */}
-                    {topMode === 'unregistered' && (
+                    {/* Mode 1: not registered → just Register. Hidden when
+                        the host context doesn't permit registration — that
+                        flow is for the desktop app. */}
+                    {topMode === 'unregistered' && allowRegistration && (
                         <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
                             <Button
                                 startIcon={<HowToRegIcon />}
@@ -493,15 +500,17 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                             >
                                 Resume Cloud
                             </Button>
-                            <Button
-                                startIcon={<LinkOffIcon />}
-                                variant="outlined"
-                                size="small"
-                                color="error"
-                                onClick={() => setDisconnectOpen(true)}
-                            >
-                                Disconnect
-                            </Button>
+                            {allowRegistration && (
+                                <Button
+                                    startIcon={<LinkOffIcon />}
+                                    variant="outlined"
+                                    size="small"
+                                    color="error"
+                                    onClick={() => setDisconnectOpen(true)}
+                                >
+                                    Disconnect
+                                </Button>
+                            )}
                         </Stack>
                     )}
 
@@ -546,15 +555,17 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                                 >
                                     Switch to Cloud-managed
                                 </Button>
-                                <Button
-                                    startIcon={<LinkOffIcon />}
-                                    variant="text"
-                                    size="small"
-                                    color="error"
-                                    onClick={() => setDisconnectOpen(true)}
-                                >
-                                    Disconnect
-                                </Button>
+                                {allowRegistration && (
+                                    <Button
+                                        startIcon={<LinkOffIcon />}
+                                        variant="text"
+                                        size="small"
+                                        color="error"
+                                        onClick={() => setDisconnectOpen(true)}
+                                    >
+                                        Disconnect
+                                    </Button>
+                                )}
                             </Stack>
                         </>
                     )}
@@ -587,15 +598,17 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                                 >
                                     Switch to xLights-managed
                                 </Button>
-                                <Button
-                                    startIcon={<LinkOffIcon />}
-                                    variant="text"
-                                    size="small"
-                                    color="error"
-                                    onClick={() => setDisconnectOpen(true)}
-                                >
-                                    Disconnect
-                                </Button>
+                                {allowRegistration && (
+                                    <Button
+                                        startIcon={<LinkOffIcon />}
+                                        variant="text"
+                                        size="small"
+                                        color="error"
+                                        onClick={() => setDisconnectOpen(true)}
+                                    >
+                                        Disconnect
+                                    </Button>
+                                )}
                             </Stack>
                         </>
                     )}
@@ -716,21 +729,25 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                             Cloud Configuration
                         </Typography>
                         <Box sx={{ flexGrow: 1 }} />
-                        <Button
-                            startIcon={<EditIcon />}
-                            variant="outlined"
-                            size="small"
-                            onClick={() => setRegDialogOpen(true)}
-                        >
-                            Edit
-                        </Button>
+                        {allowRegistration && (
+                            <Button
+                                startIcon={<EditIcon />}
+                                variant="outlined"
+                                size="small"
+                                onClick={() => setRegDialogOpen(true)}
+                            >
+                                Edit
+                            </Button>
+                        )}
                     </Box>
                     <Field label="Cloud Service URL" value={cloudConfig.cloudServiceUrl || '(not set)'} />
                     <Field label="Player ID Token" value={cloudConfig.playerIdToken || '(not set)'} />
                 </Card>
             </Box>
-            <PlayerCloudRegistrationDialog open={regDialogOpen} onClose={() => setRegDialogOpen(false)} />
-            <Dialog open={disconnectOpen} onClose={() => setDisconnectOpen(false)}>
+            {allowRegistration && (
+                <PlayerCloudRegistrationDialog open={regDialogOpen} onClose={() => setRegDialogOpen(false)} />
+            )}
+            {allowRegistration && <Dialog open={disconnectOpen} onClose={() => setDisconnectOpen(false)}>
                 <DialogTitle>Disconnect from cloud?</DialogTitle>
                 <DialogContent>
                     <DialogContentText>
@@ -745,7 +762,7 @@ export const CloudPage: React.FC<CloudPageProps> = ({ title, statusArea }) => {
                         Disconnect
                     </Button>
                 </DialogActions>
-            </Dialog>
+            </Dialog>}
         </Box>
     );
 };

--- a/packages/player-ui-components/src/components/jukebox/JukeboxScreen.tsx
+++ b/packages/player-ui-components/src/components/jukebox/JukeboxScreen.tsx
@@ -24,6 +24,7 @@ import { SortDropdown } from './SortDropdown';
 import { SongCard } from './SongCard';
 import { PlaylistDropdown } from './PlaylistDropdown';
 import type { PlaylistRecord, PlaylistItem } from '@ezplayer/ezplayer-core';
+import { isSequencePlayable } from '@ezplayer/ezplayer-core';
 import { useImageUrl } from '../../util/imageUtils';
 import { QueueAndControlStack } from '../player/QueueAndControlStack';
 import { isSongAllowedForJukebox } from '../../services/jukeboxFilter';
@@ -228,8 +229,7 @@ export function JukeboxArea({ onInteract }: JukeboxAreaProps) {
         sequenceData
             ?.filter(
                 (s: SequenceItem) =>
-                    !s.deleted &&
-                    s.render_enabled !== false &&
+                    isSequencePlayable(s) &&
                     isSongAllowedForJukebox({
                         songTags: s.settings?.tags,
                         excludedTags: jukeboxSettings?.excludedTags,
@@ -621,8 +621,7 @@ export function JukeboxScreen({ title, statusArea }: { title: string; statusArea
             sequenceData
                 ?.filter(
                     (s: SequenceItem) =>
-                        !s.deleted &&
-                        s.render_enabled !== false &&
+                        isSequencePlayable(s) &&
                         isSongAllowedForJukebox({
                             songTags: s.settings?.tags,
                             excludedTags: jukeboxSettings?.excludedTags,

--- a/packages/player-ui-components/src/components/playback-settings/sections/ShowFolderSettings.tsx
+++ b/packages/player-ui-components/src/components/playback-settings/sections/ShowFolderSettings.tsx
@@ -1,4 +1,5 @@
 import { Button, TextField, Typography } from '@mui/material';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { isElectron, ToastMsgs } from '@ezplayer/shared-ui-components';
@@ -42,6 +43,38 @@ export const ShowFolderSettings: React.FC = () => {
         }
     };
 
+    /** "Download Cloud Show" — switch the player to a fresh, cloud-managed
+     *  folder. Reuses the same `requestChooseCloudShowFolder` IPC the
+     *  out-of-the-box Welcome flow uses, so first-time and switch-later land
+     *  at the same validation + seeding path. If the chosen folder already
+     *  has a cloud-config, the existing one is opened as-is (this is also
+     *  the "reopen a previously-configured cloud folder" entry point). For
+     *  a fresh folder, main has already seeded an empty cloud-config —
+     *  CloudPage's Mode 1 ("not registered") lights up the Register flow as
+     *  soon as the user navigates to it via the sidebar. */
+    const handleDownloadCloudShow = async () => {
+        if (!isElectron() || !window.electronAPI?.requestChooseCloudShowFolder) return;
+        try {
+            const { folder, existingInstall } = await window.electronAPI.requestChooseCloudShowFolder();
+            if (!folder) return; // user cancelled (or picker rejected)
+            const message = existingInstall
+                ? `Opened existing cloud show: ${folder}`
+                : `Switched to new cloud show: ${folder}. Open the Cloud screen to register this player.`;
+            ToastMsgs.showSuccessMessage(message, {
+                theme: 'colored',
+                position: 'bottom-right',
+                autoClose: existingInstall ? 2000 : 5000,
+            });
+        } catch (error) {
+            console.error('Error setting up cloud show:', error);
+            ToastMsgs.showErrorMessage('Failed to set up cloud show', {
+                theme: 'colored',
+                position: 'bottom-right',
+                autoClose: 2000,
+            });
+        }
+    };
+
     return (
         <Box>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
@@ -61,6 +94,18 @@ export const ShowFolderSettings: React.FC = () => {
                     sx={{ '& .MuiInputBase-input': { color: 'text.primary' } }}
                 />
             </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 3, mb: 1 }}>
+                Or start fresh with a cloud-managed show: pick an empty folder and pair it with
+                your EZPlayer cloud account.
+            </Typography>
+            <Button
+                variant="outlined"
+                startIcon={<CloudDownloadIcon />}
+                onClick={handleDownloadCloudShow}
+                sx={{ whiteSpace: 'nowrap' }}
+            >
+                Download Cloud Show
+            </Button>
         </Box>
     );
 };

--- a/packages/player-ui-components/src/components/player/PlayerScreen.tsx
+++ b/packages/player-ui-components/src/components/player/PlayerScreen.tsx
@@ -2,7 +2,7 @@ import { PageHeader } from '@ezplayer/shared-ui-components';
 import { Alert, Card, CardContent, Chip, CircularProgress, Grid, Typography } from '@mui/material';
 import { Box } from '../box/Box';
 import { endOfDay, startOfDay } from 'date-fns';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store/Store';
 import { SchedulePreviewSettings } from '../../types/SchedulePreviewTypes';
@@ -203,6 +203,12 @@ const TimelineView = ({}: {}) => {
         [startTime, endTime],
     );
 
+    // Stale-while-revalidate so a loading flip doesn't unmount the graph.
+    type PreviewBundle = NonNullable<ReturnType<typeof generateSchedulePreview>> extends infer S
+        ? { background: S; main: S; startTime: number; endTime: number; errors: never[]; warnings: never[] }
+        : never;
+    const lastGoodPreviewRef = useRef<PreviewBundle | null>(null);
+
     const { data: previewData, error } = useMemo(() => {
         if (!sequences.length || !playlists.length || !todaysSchedules.length) {
             return { data: null, error: null as string | null };
@@ -236,6 +242,10 @@ const TimelineView = ({}: {}) => {
         previewWindow,
     ]);
 
+    if (previewData) lastGoodPreviewRef.current = previewData;
+    const renderableData = previewData ?? (isLoading ? lastGoodPreviewRef.current : null);
+    const noScheduleData = !sequences.length || !playlists.length || !todaysSchedules.length;
+
     return (
         <Box
             sx={{
@@ -252,14 +262,14 @@ const TimelineView = ({}: {}) => {
             )}
 
             <Box sx={{ height: '100%', overflow: 'hidden' }}>
-                {isLoading ? (
+                {renderableData ? (
+                    <GraphForSchedule data={renderableData} selectedStartTime={startTime} selectedEndTime={endTime} />
+                ) : isLoading ? (
                     <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
                         <CircularProgress />
                     </Box>
-                ) : !sequences.length || !playlists.length || !todaysSchedules.length ? (
+                ) : noScheduleData ? (
                     <Alert severity="info">No schedule data available for today.</Alert>
-                ) : previewData ? (
-                    <GraphForSchedule data={previewData} selectedStartTime={startTime} selectedEndTime={endTime} />
                 ) : (
                     <Alert severity="info">No schedule events for today.</Alert>
                 )}

--- a/packages/player-ui-components/src/components/player/QueueAndControlStack.tsx
+++ b/packages/player-ui-components/src/components/player/QueueAndControlStack.tsx
@@ -31,7 +31,7 @@ export const QueueAndControlStack: React.FC<QueueAndControlStackProps> = ({}) =>
 
             {/* Queue */}
             <Grid container spacing={2}>
-                <Grid item xs={12} md={12} lg={6} xl={4}>
+                <Grid item xs={12}>
                     {runtime?.combined?.player?.queue && (
                         <QueueCard
                             queue={runtime.combined.player.queue}

--- a/packages/player-ui-components/src/components/playlist/CreateEditPlaylist.tsx
+++ b/packages/player-ui-components/src/components/playlist/CreateEditPlaylist.tsx
@@ -10,6 +10,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { PlaylistRecord, SequenceRecord } from '@ezplayer/ezplayer-core';
+import { isSequencePlayable } from '@ezplayer/ezplayer-core';
 import { PageHeader, ToastMsgs } from '@ezplayer/shared-ui-components';
 import SearchIcon from '@mui/icons-material/Search';
 import ShuffleIcon from '@mui/icons-material/Shuffle';
@@ -800,7 +801,7 @@ export function CreateEditPlaylist({ title: _title, statusArea }: EditPlayListPr
     const filteredAndSortedSongs = useMemo(() => {
         return (sequenceData || [])
             ?.filter((song) => {
-                if (song.deleted || song.render_enabled === false) return false;
+                if (!isSequencePlayable(song)) return false;
                 // Text search filter for title/artist
                 const matchesSearch =
                     song.work?.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||

--- a/packages/player-ui-components/src/components/song/SongList.tsx
+++ b/packages/player-ui-components/src/components/song/SongList.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { PageHeader, TextField } from '@ezplayer/shared-ui-components';
 
 import type { SequenceSettings } from '@ezplayer/ezplayer-core';
+import { isSequencePlayable } from '@ezplayer/ezplayer-core';
 import { RootState } from '../..';
 
 import {
@@ -243,7 +244,7 @@ export function SongList({
     // Modify the useEffect that creates the rows data to combine local and server songs
     useEffect(() => {
         // Create nonnull array of server and local songs
-        const allSongs = (sequenceData || []).filter((s) => !s.deleted && s.render_enabled !== false);
+        const allSongs = (sequenceData || []).filter(isSequencePlayable);
 
         if (!allSongs.length) {
             setRows([]);


### PR DESCRIPTION
Fixes based on doc effort, OH mini findings, and other tests:
Generic
- Audio window getting throttled (suspected to cause the "Start time way off" console logs)
- Timeline view cutting in and out
- Queue on player view not proper width when it switches to multicolumn

Cloud-adjacent
- Songs listed in jukebox for playback when the cloud was still rendering them
- Hang w/ cloud registration from scratch
- New option to start a new show folder from cloud