### PR TITLE
Fix rollup

### DIFF
--- a/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
@@ -139,16 +139,12 @@ export function attachWebSocketProxy(httpServer: http.Server): void {
             return;
         }
 
-        const raw = url.slice(PROXY_PREFIX.length);
-        if (!raw) {
-            socket.destroy();
-            return;
-        }
-
-        let target: URL;
-        try {
-            target = new URL(raw);
-        } catch {
+        // Reuse the HTTP target parser so the WS path accepts the same forms as
+        // the HTTP path — notably a bare host (`/proxy/<host>/<path>`). Before,
+        // this used a raw `new URL(raw)` with no scheme defaulting, so a
+        // scheme-less target threw and the upgrade socket was silently dropped.
+        const target = parseTargetUrl(url);
+        if (!target) {
             socket.destroy();
             return;
         }
@@ -179,18 +175,22 @@ export function attachWebSocketProxy(httpServer: http.Server): void {
                     }
                 });
 
-                // Close propagation
-                clientWs.on('close', (code, reason) => {
-                    if (targetWs.readyState === WebSocket.OPEN) {
-                        targetWs.close(code, reason);
+                // Close propagation. Only application-valid codes (1000, or
+                // 3000–4999) may be passed to ws.close(); reserved codes such as
+                // 1005 (no status) and 1006 (abnormal) are reported on the
+                // 'close' event but throw if handed back to close() — which would
+                // otherwise be an uncaught exception that crashes the server.
+                const closeSafely = (ws: WebSocket, code: number, reason: Buffer) => {
+                    if (ws.readyState !== WebSocket.OPEN) return;
+                    if (code === 1000 || (code >= 3000 && code <= 4999)) {
+                        ws.close(code, reason);
+                    } else {
+                        ws.close();
                     }
-                });
+                };
 
-                targetWs.on('close', (code, reason) => {
-                    if (clientWs.readyState === WebSocket.OPEN) {
-                        clientWs.close(code, reason);
-                    }
-                });
+                clientWs.on('close', (code, reason) => closeSafely(targetWs, code, reason));
+                targetWs.on('close', (code, reason) => closeSafely(clientWs, code, reason));
 
                 // Error propagation
                 clientWs.on('error', () => {

--- a/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
@@ -39,12 +39,10 @@ function filterHeaders(raw: http.IncomingHttpHeaders): http.OutgoingHttpHeaders 
 }
 
 /**
- * Build forwarded request headers from `rawHeaders`, preserving the original
- * header-name case. `req.headers` lowercases every name, which breaks devices
- * with case-sensitive header parsing (e.g. HinksPix only honors `BLK`, not
- * `blk`). `rawHeaders` is a flat [name, value, name, value, …] array that keeps
- * the on-the-wire case. `host` is dropped here because the caller overrides it
- * with the target host (avoids sending a duplicate Host header).
+ * Build forwarded request headers preserving original header-name case.
+ * `req.headers` lowercases names, breaking case-sensitive devices (e.g. HinksPix
+ * only honors `BLK`, not `blk`); `rawHeaders` keeps the wire case. `host` is
+ * dropped — the caller sets it from the target.
  */
 function filterRawHeaders(rawHeaders: string[]): http.OutgoingHttpHeaders {
     const out: http.OutgoingHttpHeaders = {};
@@ -97,8 +95,6 @@ export function createProxyMiddleware(): Koa.Middleware {
 
         const transport = target.protocol === 'https:' ? https : http;
 
-        // Preserve original header-name case (see filterRawHeaders) so
-        // case-sensitive devices behind the proxy receive headers as sent.
         const outHeaders = filterRawHeaders(ctx.req.rawHeaders);
         outHeaders['host'] = target.host;
 
@@ -168,10 +164,8 @@ export function attachWebSocketProxy(httpServer: http.Server): void {
             return;
         }
 
-        // Reuse the HTTP target parser so the WS path accepts the same forms as
-        // the HTTP path — notably a bare host (`/proxy/<host>/<path>`). Before,
-        // this used a raw `new URL(raw)` with no scheme defaulting, so a
-        // scheme-less target threw and the upgrade socket was silently dropped.
+        // Reuse the HTTP target parser so the WS path accepts the same target
+        // forms, including a bare host (`/proxy/<host>`).
         const target = parseTargetUrl(url);
         if (!target) {
             socket.destroy();
@@ -204,11 +198,9 @@ export function attachWebSocketProxy(httpServer: http.Server): void {
                     }
                 });
 
-                // Close propagation. Only application-valid codes (1000, or
-                // 3000–4999) may be passed to ws.close(); reserved codes such as
-                // 1005 (no status) and 1006 (abnormal) are reported on the
-                // 'close' event but throw if handed back to close() — which would
-                // otherwise be an uncaught exception that crashes the server.
+                // ws.close() only accepts application close codes (1000, or
+                // 3000–4999); reserved codes like 1005/1006 throw, so fall back
+                // to a plain close.
                 const closeSafely = (ws: WebSocket, code: number, reason: Buffer) => {
                     if (ws.readyState !== WebSocket.OPEN) return;
                     if (code === 1000 || (code >= 3000 && code <= 4999)) {

--- a/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/proxy-middleware.ts
@@ -38,6 +38,33 @@ function filterHeaders(raw: http.IncomingHttpHeaders): http.OutgoingHttpHeaders 
     return out;
 }
 
+/**
+ * Build forwarded request headers from `rawHeaders`, preserving the original
+ * header-name case. `req.headers` lowercases every name, which breaks devices
+ * with case-sensitive header parsing (e.g. HinksPix only honors `BLK`, not
+ * `blk`). `rawHeaders` is a flat [name, value, name, value, …] array that keeps
+ * the on-the-wire case. `host` is dropped here because the caller overrides it
+ * with the target host (avoids sending a duplicate Host header).
+ */
+function filterRawHeaders(rawHeaders: string[]): http.OutgoingHttpHeaders {
+    const out: http.OutgoingHttpHeaders = {};
+    for (let i = 0; i + 1 < rawHeaders.length; i += 2) {
+        const key = rawHeaders[i];
+        const value = rawHeaders[i + 1];
+        const lower = key.toLowerCase();
+        if (HOP_BY_HOP.has(lower) || lower === 'host') continue;
+        const existing = out[key];
+        if (existing === undefined) {
+            out[key] = value;
+        } else if (Array.isArray(existing)) {
+            existing.push(value);
+        } else {
+            out[key] = [existing as string, value];
+        }
+    }
+    return out;
+}
+
 /** Parse and validate the target URL from the proxy path. */
 function parseTargetUrl(originalUrl: string): URL | null {
     let raw = originalUrl.slice(PROXY_PREFIX.length);
@@ -70,7 +97,9 @@ export function createProxyMiddleware(): Koa.Middleware {
 
         const transport = target.protocol === 'https:' ? https : http;
 
-        const outHeaders = filterHeaders(ctx.req.headers);
+        // Preserve original header-name case (see filterRawHeaders) so
+        // case-sensitive devices behind the proxy receive headers as sent.
+        const outHeaders = filterRawHeaders(ctx.req.rawHeaders);
         outHeaders['host'] = target.host;
 
         await new Promise<void>((resolve) => {

--- a/apps/ezplayer-ui-electron/package.json
+++ b/apps/ezplayer-ui-electron/package.json
@@ -10,7 +10,7 @@
     },
     "private": true,
     "license": "AGPL-3.0",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "main": "dist/main.js",
     "type": "module",
     "build": {

--- a/apps/ezplayer-ui-embedded/package.json
+++ b/apps/ezplayer-ui-embedded/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ezplayer/ui-embedded",
     "private": true,
-    "version": "0.5.1",
+    "version": "0.5.2",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/apps/ezplayer-ui-embedded/src/router/router.tsx
+++ b/apps/ezplayer-ui-embedded/src/router/router.tsx
@@ -107,7 +107,14 @@ const EmbeddedSettingsPage = () => {
 const allMenuRoutes: MenuRoute[] = [
     {
         path: ROUTES.PLAYER,
-        element: <PlayerScreen title="Player" statusArea={getStatusArea()} allowVolumeControl={!isKiosk} />,
+        element: (
+            <PlayerScreen
+                title="Player"
+                statusArea={getStatusArea()}
+                allowVolumeControl={!isKiosk}
+                allowStopControls={!isKiosk}
+            />
+        ),
         sidebar: { icon: <TableChartTwoToneIcon />, label: 'Player' },
     },
     {
@@ -136,7 +143,7 @@ const allMenuRoutes: MenuRoute[] = [
     },
     {
         path: ROUTES.JUKEBOXSCR,
-        element: <JukeboxScreen title="Jukebox" statusArea={getStatusArea()} />,
+        element: <JukeboxScreen title="Jukebox" statusArea={getStatusArea()} allowStopControls={!isKiosk} />,
         sidebar: { icon: <PlayArrow />, label: 'Jukebox' },
     },
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ezplayer/ezplayer",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "private": true,
     "type": "module",
     "repository": {

--- a/packages/player-ui-components/src/components/jukebox/JukeboxScreen.tsx
+++ b/packages/player-ui-components/src/components/jukebox/JukeboxScreen.tsx
@@ -581,7 +581,16 @@ export function JukeboxFullScreen() {
     );
 }
 
-export function JukeboxScreen({ title, statusArea }: { title: string; statusArea: React.ReactNode[] }) {
+export function JukeboxScreen({
+    title,
+    statusArea,
+    allowStopControls = true,
+}: {
+    title: string;
+    statusArea: React.ReactNode[];
+    /** Allow End/Abort playback controls. False in kiosk so a public display can't stop the show. */
+    allowStopControls?: boolean;
+}) {
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const dispatch = useDispatch<AppDispatch>();
@@ -754,7 +763,7 @@ export function JukeboxScreen({ title, statusArea }: { title: string; statusArea
                 }}
             >
                 {/* Playback Queue Card */}
-                <QueueAndControlStack />
+                <QueueAndControlStack allowStopControls={allowStopControls} />
 
                 {/* Search and Sort Controls */}
                 <Box

--- a/packages/player-ui-components/src/components/player-cloud-registration/CloudPollingEditor.tsx
+++ b/packages/player-ui-components/src/components/player-cloud-registration/CloudPollingEditor.tsx
@@ -136,12 +136,12 @@ export const CloudPollingScheduleEditor: React.FC = () => {
             {/* Schedule list (only meaningful in scheduled mode, but always shown so the
                 user can prepare windows before flipping the switch). */}
             <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                Allowed Windows ({schedule.length})
+                Allowed Times ({schedule.length})
             </Typography>
             {schedule.length === 0 ? (
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                    No windows defined.
-                    {mode === 'scheduled' && ' In scheduled mode with no windows, content polling is suspended.'}
+                    No allowed times defined.
+                    {mode === 'scheduled' && ' In scheduled mode with no allowed times, content polling is suspended.'}
                 </Typography>
             ) : (
                 <List dense sx={{ mb: 2 }}>
@@ -183,12 +183,12 @@ export const CloudPollingScheduleEditor: React.FC = () => {
                     setAddOpen(true);
                 }}
             >
-                Add Window
+                Add Sync Time Window to Schedule
             </Button>
 
             {/* Add window dialog */}
             <Dialog open={addOpen} onClose={() => setAddOpen(false)}>
-                <DialogTitle>Add Polling Window</DialogTitle>
+                <DialogTitle>Add Sync Time Window</DialogTitle>
                 <DialogContent>
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1, minWidth: 420 }}>
                         <FormControl fullWidth size="small">

--- a/packages/player-ui-components/src/components/player/NowPlayingCard.tsx
+++ b/packages/player-ui-components/src/components/player/NowPlayingCard.tsx
@@ -29,6 +29,8 @@ interface NowPlayingCardProps {
      *  that pops the default/scheduled volume settings. When false, the volume is a
      *  read-only meter. */
     allowVolumeControl?: boolean;
+    /** When false (kiosk), the playback controls hide End/Abort. Defaults to true. */
+    allowStopControls?: boolean;
 }
 
 const formatTime = (timestamp?: number | string) => {
@@ -48,6 +50,7 @@ export const NowPlayingCard = ({
     className,
     compact = false,
     allowVolumeControl = false,
+    allowStopControls = true,
 }: NowPlayingCardProps) => {
     if (player.ptype !== 'EZP') {
         return null;
@@ -191,7 +194,7 @@ export const NowPlayingCard = ({
                 )}
 
                 {/* Playback controls — only when playing or paused */}
-                {isActive && <QueueAndControlStack />}
+                {isActive && <QueueAndControlStack allowStopControls={allowStopControls} />}
 
                 {/* Reload schedule button — only when stopped */}
                 {!isActive && (

--- a/packages/player-ui-components/src/components/player/PlaybackControls.tsx
+++ b/packages/player-ui-components/src/components/player/PlaybackControls.tsx
@@ -7,7 +7,13 @@ import { ControlButton } from './ControlButton';
 import { AppDispatch, RootState } from '../../store/Store';
 import { callImmediateCommand } from '../../store/slices/RuntimeStore';
 
-export const PlaybackControls: React.FC = () => {
+interface PlaybackControlsProps {
+    /** When false (kiosk mode), hide the "End" (graceful stop) and "Abort" (hard stop)
+     *  buttons so a public display can't stop the show. Defaults to true. */
+    allowStopControls?: boolean;
+}
+
+export const PlaybackControls: React.FC<PlaybackControlsProps> = ({ allowStopControls = true }) => {
     const runtime = useSelector((state: RootState) => state.runtime);
     const dispatch = useDispatch<AppDispatch>();
 
@@ -61,8 +67,10 @@ export const PlaybackControls: React.FC = () => {
                 onClick={handlePlayPause}
             />
             <ControlButton icon={SkipNext} label="Skip" onClick={handleSkip} />
-            <ControlButton icon={Stop} label="End" onClick={handleStopGraceful} />
-            <ControlButton icon={StopCircle} label="Abort" color="error" onClick={handleStopNow} />
+            {allowStopControls && <ControlButton icon={Stop} label="End" onClick={handleStopGraceful} />}
+            {allowStopControls && (
+                <ControlButton icon={StopCircle} label="Abort" color="error" onClick={handleStopNow} />
+            )}
             {/*<ControlButton icon={Delete} label="Clear Queue" color="warning" onClick={handleClearRequests} />*/}
             {/*
             <ControlButton

--- a/packages/player-ui-components/src/components/player/PlayerScreen.tsx
+++ b/packages/player-ui-components/src/components/player/PlayerScreen.tsx
@@ -16,9 +16,17 @@ interface PlayerScreenProps {
     statusArea: React.ReactNode[];
     /** Allow live master-volume control + the volume-settings gear on the Now Playing card. */
     allowVolumeControl?: boolean;
+    /** Allow End/Abort playback controls. False in kiosk so a public display can't stop the show. */
+    allowStopControls?: boolean;
 }
 
-const StatusCards = ({ allowVolumeControl }: { allowVolumeControl?: boolean }) => {
+const StatusCards = ({
+    allowVolumeControl,
+    allowStopControls,
+}: {
+    allowVolumeControl?: boolean;
+    allowStopControls?: boolean;
+}) => {
     const runtime = useSelector((state: RootState) => state.runtime);
 
     return (
@@ -31,6 +39,7 @@ const StatusCards = ({ allowVolumeControl }: { allowVolumeControl?: boolean }) =
                             player={runtime.combined.player}
                             compact={true}
                             allowVolumeControl={allowVolumeControl}
+                            allowStopControls={allowStopControls}
                         />
                     ) : runtime.combined?.show ? (
                         <Card sx={{ height: '100%' }}>
@@ -278,7 +287,7 @@ const TimelineView = ({}: {}) => {
     );
 };
 
-export const PlayerScreen = ({ title, statusArea, allowVolumeControl }: PlayerScreenProps) => {
+export const PlayerScreen = ({ title, statusArea, allowVolumeControl, allowStopControls }: PlayerScreenProps) => {
     return (
         <Box
             sx={{
@@ -294,7 +303,7 @@ export const PlayerScreen = ({ title, statusArea, allowVolumeControl }: PlayerSc
             </Box>
 
             {/* Now Playing Card and Controller Status */}
-            <StatusCards allowVolumeControl={allowVolumeControl} />
+            <StatusCards allowVolumeControl={allowVolumeControl} allowStopControls={allowStopControls} />
 
             {/* Timeline View */}
             <TimelineView />

--- a/packages/player-ui-components/src/components/player/QueueAndControlStack.tsx
+++ b/packages/player-ui-components/src/components/player/QueueAndControlStack.tsx
@@ -8,9 +8,12 @@ import { AppDispatch, RootState } from '../../store/Store';
 import { callImmediateCommand } from '../../store/slices/RuntimeStore';
 import { PlaybackControls } from './PlaybackControls';
 
-interface QueueAndControlStackProps {}
+interface QueueAndControlStackProps {
+    /** Forwarded to PlaybackControls — hides End/Abort in kiosk mode. Defaults to true. */
+    allowStopControls?: boolean;
+}
 
-export const QueueAndControlStack: React.FC<QueueAndControlStackProps> = ({}) => {
+export const QueueAndControlStack: React.FC<QueueAndControlStackProps> = ({ allowStopControls = true }) => {
     const runtime = useSelector((state: RootState) => state.runtime);
     const dispatch = useDispatch<AppDispatch>();
 
@@ -26,7 +29,7 @@ export const QueueAndControlStack: React.FC<QueueAndControlStackProps> = ({}) =>
         <Box sx={{ px: 2, pb: 2, flexShrink: 0 }}>
             {/* Playback control buttons */}
             <Box sx={{ mb: 2 }}>
-                <PlaybackControls />
+                <PlaybackControls allowStopControls={allowStopControls} />
             </Box>
 
             {/* Queue */}

--- a/packages/player-ui-components/src/components/preview-3d/HouseMesh.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/HouseMesh.tsx
@@ -450,6 +450,18 @@ function createAssetLoadingManager(
             }
             // External or already-resolved URL — leave it alone.
             if (!assetPath) return url;
+        } else if (frameServerUrl && url.startsWith(`${frameServerUrl.replace(/\/+$/, '')}/api/`) && !url.includes('show-file')) {
+            // Path-only proxy base (cloud SPA `frameServerUrl`, e.g. `/api/enduserspa/proxy/<token>`):
+            // the http(s) origin check above can't fire because `new URL()` rejects a path-only base,
+            // so an MTL-referenced texture would otherwise fall through to the relative branch and get
+            // `objDir + <full-proxy-path>` (→ a mangled show-file path → 404; this is why mesh textures
+            // loaded over LAN but not over the cloud). MTLLoader appended the texture filename onto
+            // `<base>/api/`, so recover the trailing path and resolve it against the OBJ dir — mirroring
+            // the absolute-URL case above.
+            const apiBase = `${frameServerUrl.replace(/\/+$/, '')}/api/`;
+            const rest = url.slice(apiBase.length).split('?')[0];
+            if (rest) assetPath = objDir + rest;
+            if (!assetPath) return url;
         } else {
             // Relative / plain filename, e.g. "texture_1001.png"
             assetPath = objDir + url;

--- a/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
@@ -30,7 +30,13 @@ import { Viewer3D, type CameraState3D } from './Viewer3D';
 import { Viewer2D, type CameraState2D } from './Viewer2D';
 import { useOrbitPreference } from '../../util/orbitPreference';
 import { ModelList } from './ModelList';
-import { PreviewSettings, SettingsButton, type PreviewSettingsData } from './PreviewSettings';
+import {
+    PreviewSettings,
+    SettingsButton,
+    PIXEL_SIZE_MIN,
+    PIXEL_SIZE_MAX,
+    type PreviewSettingsData,
+} from './PreviewSettings';
 import { convertXmlCoordinatesToModel3D } from '../../services/model3dLoader';
 import type { Model3DData, ModelMetadata, SelectionState, ViewObject, LayoutSettings } from '../../types/model3d';
 import type { LayoutGroupInfo, MhFixtureInfo, ViewpointInfo } from 'xllayoutcalcs';
@@ -721,7 +727,7 @@ export const Preview3D: React.FC<Preview3DProps> = ({
     // Handle settings change
     const handleSettingsChange = useCallback((newSettings: PreviewSettingsData) => {
         // Validate and clamp values
-        const clampedPixelSize = Math.max(0.5, Math.min(3.0, Number(newSettings.pixelSize) || 1.0));
+        const clampedPixelSize = Math.max(PIXEL_SIZE_MIN, Math.min(PIXEL_SIZE_MAX, Number(newSettings.pixelSize) || 1.0));
         const clampedMultiplier = Math.max(0, Math.min(200, Number(newSettings.brightnessMultiplier) || 100));
 
         setPreviewSettings({
@@ -759,9 +765,10 @@ export const Preview3D: React.FC<Preview3DProps> = ({
         setShouldAutoFit(false);
     }, []);
 
-    // Handle save as default view — persists only the camera position/angle/zoom
-    // and 2D/3D mode. Slider values (pixel size, brightness) are NOT saved here;
-    // they are saved separately via the OK button flow.
+    // Handle save as default view — persists the full current view: camera position/angle/zoom,
+    // 2D/3D mode, AND the slider values (pixel size, brightness). "Set as Default" is expected to
+    // capture everything currently shown; OK persists the sliders too, but a user who tweaks pixel
+    // size and clicks "Set as Default" should not lose it.
     const handleSaveAsDefault = useCallback(() => {
         const currentCameraState2D = getCurrentCameraState2DRef.current?.() ?? null;
         const currentCameraState3D = getCurrentCameraState3DRef.current?.() ?? null;
@@ -792,12 +799,14 @@ export const Preview3D: React.FC<Preview3DProps> = ({
                     mode: viewMode,
                     cameraState2D: currentCameraState2D,
                     cameraState3D: currentCameraState3D,
+                    pixelSize: previewSettings.pixelSize,
+                    brightnessMultiplier: previewSettings.brightnessMultiplier,
                 }),
             );
         } catch (err) {
             console.error('[Preview3D] Failed to save default view:', err);
         }
-    }, [viewMode, previewSettingsStorageKey, previewSelection]);
+    }, [viewMode, previewSettings, previewSettingsStorageKey, previewSelection]);
 
     // Handle model selection from model list
     const handleModelSelect = useCallback(

--- a/packages/player-ui-components/src/components/preview-3d/PreviewSettings.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/PreviewSettings.tsx
@@ -32,12 +32,25 @@ const contentBoxStyle: React.CSSProperties = {
     gap: 16,
 };
 
-const pixelSizeMarks: SliderMark[] = [
-    { value: 0.5, label: '0.5x' },
-    { value: 1.0, label: '1x' },
-    { value: 2.0, label: '2x' },
-    { value: 3.0, label: '3x' },
-];
+// Pixel-size multiplier bounds. The slider is driven on a logarithmic (geometric) scale
+// so there's fine control at small sizes and it still reaches large pixels — equal slider
+// travel multiplies the size by a constant factor (…0.5 → 1 → 2 → 4 → 8 → 16). The stored
+// value stays the real multiplier; only the slider position is transformed.
+export const PIXEL_SIZE_MIN = 0.5;
+export const PIXEL_SIZE_MAX = 16;
+const PIXEL_SLIDER_RANGE = 1000; // internal linear position space for the slider
+
+const pixelToPos = (px: number): number => {
+    const clamped = Math.max(PIXEL_SIZE_MIN, Math.min(PIXEL_SIZE_MAX, px));
+    return (PIXEL_SLIDER_RANGE * Math.log(clamped / PIXEL_SIZE_MIN)) / Math.log(PIXEL_SIZE_MAX / PIXEL_SIZE_MIN);
+};
+const posToPixel = (pos: number): number =>
+    PIXEL_SIZE_MIN * Math.pow(PIXEL_SIZE_MAX / PIXEL_SIZE_MIN, pos / PIXEL_SLIDER_RANGE);
+
+const pixelSizeMarks: SliderMark[] = [0.5, 1, 2, 4, 8, 16].map((v) => ({
+    value: pixelToPos(v),
+    label: `${v}x`,
+}));
 
 const brightnessMarks: SliderMark[] = [
     { value: 0, label: '0%' },
@@ -127,9 +140,10 @@ export const PreviewSettings: React.FC<PreviewSettingsProps> = ({
 
     const handlePixelSizeChange = useCallback(
         (_event: Event | React.SyntheticEvent, value: number | number[]) => {
-            const raw = typeof value === 'number' ? value : value[0];
-            const clamped = Math.max(0.5, Math.min(3.0, raw));
-            const next = { ...localSettingsRef.current, pixelSize: clamped };
+            // Slider operates in log "position" space; convert back to the real multiplier.
+            const pos = typeof value === 'number' ? value : value[0];
+            const pixel = Math.max(PIXEL_SIZE_MIN, Math.min(PIXEL_SIZE_MAX, posToPixel(pos)));
+            const next = { ...localSettingsRef.current, pixelSize: pixel };
             localSettingsRef.current = next;
             setLocalSettings(next);
             onSettingsChange(next);
@@ -166,7 +180,12 @@ export const PreviewSettings: React.FC<PreviewSettingsProps> = ({
                 },
             ]}
         >
-            <ClickAwayListener onClickAway={handleCancel}>
+            {/* Dismiss on a press OUTSIDE the popper, not on click/touch-end. With the default
+                ('onClick'), dragging a Slider thumb and releasing the mouse outside the popper
+                synthesizes a document-level click → the dialog closed and reverted the setting.
+                Listening on mousedown/touchstart means a drag that starts on the thumb never
+                triggers dismissal. */}
+            <ClickAwayListener onClickAway={handleCancel} mouseEvent="onMouseDown" touchEvent="onTouchStart">
                 <Paper sx={popoverPaperSx} elevation={8}>
                     <Box style={contentBoxStyle}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
@@ -186,14 +205,14 @@ export const PreviewSettings: React.FC<PreviewSettingsProps> = ({
                                 Pixel Size: {localSettings.pixelSize.toFixed(2)}x
                             </Typography>
                             <Slider
-                                value={localSettings.pixelSize}
+                                value={pixelToPos(localSettings.pixelSize)}
                                 onChange={handlePixelSizeChange}
-                                min={0.5}
-                                max={3.0}
-                                step={0.1}
+                                min={0}
+                                max={PIXEL_SLIDER_RANGE}
+                                step={1}
                                 marks={pixelSizeMarks}
                                 valueLabelDisplay="auto"
-                                valueLabelFormat={(value) => `${value.toFixed(1)}x`}
+                                valueLabelFormat={(pos) => `${posToPixel(pos).toFixed(posToPixel(pos) < 2 ? 1 : 0)}x`}
                             />
                         </Box>
 

--- a/packages/player-ui-components/src/components/preview-3d/Viewer2D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Viewer2D.tsx
@@ -1046,13 +1046,13 @@ export const Viewer2D: React.FC<Viewer2DProps> = ({
                         variant="caption"
                         sx={{ color: 'rgba(255, 255, 255, 0.95)', textShadow: '0 1px 2px rgba(0,0,0,0.8)' }}
                     >
-                        🖱️ Right drag: Pan
+                        🖱️ Middle drag: Pan
                     </Typography>
                     <Typography
                         variant="caption"
                         sx={{ color: 'rgba(255, 255, 255, 0.95)', textShadow: '0 1px 2px rgba(0,0,0,0.8)' }}
                     >
-                        🖱️ Scroll: Zoom
+                        🖱️ Right drag / Scroll: Zoom
                     </Typography>
                 </Box>
             )}
@@ -1114,8 +1114,11 @@ export const Viewer2D: React.FC<Viewer2DProps> = ({
                             screenSpacePanning={true}
                             mouseButtons={{
                                 LEFT: THREE.MOUSE.PAN,
-                                MIDDLE: THREE.MOUSE.DOLLY,
-                                RIGHT: THREE.MOUSE.PAN,
+                                // Middle also pans, for consistency with the 3D view and xLights.
+                                MIDDLE: THREE.MOUSE.PAN,
+                                // Right dollies (zoom) so a plain 2-button, no-wheel mouse can still
+                                // zoom — pan is already covered by left + middle.
+                                RIGHT: THREE.MOUSE.DOLLY,
                             }}
                         />
                         <Scene2DContent


### PR DESCRIPTION
v0.5.2 candidate
Proxy fixes - 2x web socket and 1x header preservation
Live preview enhancements - middle button consistency, pixel size easier to work with and gets saved as "Default"
Attempt asset resolver fix for #143 (will not be verifiable until cloud deployment occurs)
Kiosk should not support big red Abort button
"Add Window" was confusing to user (understandably)
