### PR TITLE
Fix asset resolved when source is Windows but Linux is the player

### DIFF
--- a/apps/ezplayer-ui-electron/mainsrc/data/layoutAssets.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/data/layoutAssets.ts
@@ -1,5 +1,6 @@
 import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { isAssetPathAbsolute } from '@ezplayer/epp';
 
 /**
  * Attribute names in xLights XML that carry filesystem references we need to bundle
@@ -47,7 +48,11 @@ export function extractAssetRefs(xmlText: string): string[] {
  */
 export function refToShowFolderRelative(ref: string, showFolder: string): string | null {
     const norm = ref.replace(/\\/g, '/');
-    if (path.isAbsolute(norm)) {
+    if (isAssetPathAbsolute(norm)) {
+        // Foreign-platform absolute paths (C:\... on a Linux player) are never
+        // host-resolvable — path.relative would treat them as relative and
+        // produce garbage; send them straight to the basename fallback.
+        if (!path.isAbsolute(norm)) return null;
         const rel = path.relative(showFolder, norm);
         if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null;
         return rel.replace(/\\/g, '/');

--- a/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
+++ b/apps/ezplayer-ui-electron/mainsrc/workers/playbackmaster.ts
@@ -53,6 +53,7 @@ import {
     CacheStats,
     loadXmlFile,
     getNumAttrDef,
+    resolveShowAssetPath,
 } from '@ezplayer/epp';
 
 import {
@@ -1171,31 +1172,11 @@ async function buildShowFolderIndex(folder: string, maxDepth = 5): Promise<Map<s
     return index;
 }
 
-/**
- * Resolve a file path from the XML to a show-folder-relative path.
- * If the path is already relative, normalises slashes and returns it.
- * If absolute and inside the show folder, strips the prefix.
- * Otherwise looks up the basename in the pre-built file index.
- */
-function resolveFilePathFromIndex(
-    filePath: string,
-    resolvedShow: string,
-    fileIndex: Map<string, string>,
-): string | undefined {
-    if (!path.isAbsolute(filePath)) {
-        return filePath.replace(/\\/g, '/');
-    }
-    const resolvedFile = path.resolve(filePath);
-    if (
-        resolvedFile.toLowerCase().startsWith(resolvedShow.toLowerCase() + path.sep.toLowerCase()) ||
-        resolvedFile.toLowerCase() === resolvedShow.toLowerCase()
-    ) {
-        return path.relative(resolvedShow, resolvedFile).replace(/\\/g, '/');
-    }
-    // Fall back to index lookup by basename
-    const basename = path.basename(filePath);
-    return fileIndex.get(basename.toLowerCase());
-}
+// Resolve a file path from the XML to a show-folder-relative path.
+// resolveShowAssetPath (epp) handles foreign-platform absolute paths too —
+// a layout authored on Windows and copied to a Linux player carries C:\...
+// refs that POSIX path.isAbsolute doesn't recognize as absolute.
+const resolveFilePathFromIndex = resolveShowAssetPath;
 
 ////////
 // Load XML coordinates independently (can be called before processQueue)

--- a/packages/epp/src/index.ts
+++ b/packages/epp/src/index.ts
@@ -32,6 +32,8 @@ export { ArrayBufferPool, BufferPool } from './util/BufferRecycler';
 
 export { XMLConstants, getAttrDef, getBoolAttrDef, getIntAttrDef, getNumAttrDef, getElementByTag, newDocument } from './util/XMLUtil';
 
+export { isAssetPathAbsolute, resolveShowAssetPath } from './util/ShowAssetPath';
+
 export {
     AwaitRequest,
     BudgetCalculator,

--- a/packages/epp/src/util/ShowAssetPath.test.ts
+++ b/packages/epp/src/util/ShowAssetPath.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+import { isAssetPathAbsolute, resolveShowAssetPath } from './ShowAssetPath';
+
+// The incident this guards against: a layout authored on Windows carries
+// C:\...\image.jpg refs; the show folder is copied to a Linux player. POSIX
+// path.isAbsolute says false for drive-letter paths, so the old resolver
+// passed them through as "relative" and the server 400'd them — images
+// worked on the Windows machine and silently vanished on the Pi.
+
+const index = new Map<string, string>([
+    ['snowman.jpg', 'images/snowman.jpg'],
+    ['house.obj', 'meshes/house.obj'],
+]);
+
+describe('isAssetPathAbsolute', () => {
+    test('detects foreign-platform absolute forms on any host', () => {
+        expect(isAssetPathAbsolute('C:\\Users\\chuck\\Pictures\\snowman.jpg')).toBe(true);
+        expect(isAssetPathAbsolute('C:/Users/chuck/Pictures/snowman.jpg')).toBe(true);
+        expect(isAssetPathAbsolute('\\\\nas\\share\\snowman.jpg')).toBe(true);
+        expect(isAssetPathAbsolute('/home/pi/show/images/snowman.jpg')).toBe(true);
+    });
+
+    test('leaves relative refs alone', () => {
+        expect(isAssetPathAbsolute('images/snowman.jpg')).toBe(false);
+        expect(isAssetPathAbsolute('images\\snowman.jpg')).toBe(false);
+    });
+});
+
+describe('resolveShowAssetPath', () => {
+    test('Windows absolute ref on a POSIX show folder rebases by basename', () => {
+        // The exact Pi scenario: foreign drive-letter path, file copied into the show folder.
+        expect(resolveShowAssetPath('C:\\Users\\chuck\\Pictures\\snowman.jpg', '/home/pi/show', index)).toBe(
+            'images/snowman.jpg',
+        );
+    });
+
+    test('Windows absolute ref gets its basename despite POSIX path.basename semantics', () => {
+        // Backslash is not a separator on POSIX; the resolver must split after normalizing.
+        expect(resolveShowAssetPath('C:\\Elsewhere\\house.obj', '/home/pi/show', index)).toBe('meshes/house.obj');
+    });
+
+    test('absolute ref inside the show folder is relativized (case-insensitive)', () => {
+        expect(
+            resolveShowAssetPath('C:\\Shows\\My Show\\images\\snowman.jpg', 'C:\\shows\\my show', new Map()),
+        ).toBe('images/snowman.jpg');
+        expect(resolveShowAssetPath('/home/pi/show/images/snowman.jpg', '/home/pi/show', new Map())).toBe(
+            'images/snowman.jpg',
+        );
+    });
+
+    test('relative refs pass through with slashes normalized, no existence check', () => {
+        expect(resolveShowAssetPath('images\\snowman.jpg', '/home/pi/show', new Map())).toBe('images/snowman.jpg');
+        expect(resolveShowAssetPath('images/snowman.jpg', '/home/pi/show', new Map())).toBe('images/snowman.jpg');
+    });
+
+    test('absolute ref outside the show folder with no index match is unresolved', () => {
+        expect(resolveShowAssetPath('C:\\Users\\chuck\\gone.png', '/home/pi/show', index)).toBeUndefined();
+        expect(resolveShowAssetPath('/etc/passwd', '/home/pi/show', index)).toBeUndefined();
+    });
+
+    test('UNC ref rebases by basename', () => {
+        expect(resolveShowAssetPath('\\\\nas\\share\\snowman.jpg', '/home/pi/show', index)).toBe(
+            'images/snowman.jpg',
+        );
+    });
+});

--- a/packages/epp/src/util/ShowAssetPath.ts
+++ b/packages/epp/src/util/ShowAssetPath.ts
@@ -1,0 +1,62 @@
+import * as path from 'path';
+
+/**
+ * Cross-platform absolute-path detection for layout asset references.
+ *
+ * xLights writes machine-local absolute paths into xlights_rgbeffects.xml
+ * (ObjFile, Image, backgroundImage, ...). When a show folder authored on
+ * Windows is copied to a Linux player (or vice versa), the reference keeps
+ * the foreign platform's shape: `path.isAbsolute` on POSIX does not
+ * recognize `C:\...` / `C:/...` / `\\server\share`, so a naive check treats
+ * the foreign absolute path as relative and passes it through — the server
+ * then rejects it and the asset silently fails to display.
+ */
+export function isAssetPathAbsolute(p: string): boolean {
+    return path.isAbsolute(p) || /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith('\\\\');
+}
+
+/**
+ * Resolve a layout asset reference to a show-folder-relative path
+ * (forward slashes), platform-independently.
+ *
+ *  - Relative refs pass through with slashes normalized.
+ *  - Absolute refs (native OR foreign-platform) inside the show folder are
+ *    relativized (case-insensitive prefix match, like xLights on Windows).
+ *  - Absolute refs outside the show folder fall back to a basename lookup
+ *    in `fileIndex` (lowercase basename → show-folder-relative path).
+ *
+ * Returns `undefined` when the ref is absolute, outside the show folder,
+ * and no same-named file exists in the index.
+ *
+ * @param resolvedShowFolder Host-native absolute show folder path
+ *                           (already through `path.resolve`).
+ */
+export function resolveShowAssetPath(
+    filePath: string,
+    resolvedShowFolder: string,
+    fileIndex: Map<string, string>,
+): string | undefined {
+    if (!isAssetPathAbsolute(filePath)) {
+        return filePath.replace(/\\/g, '/');
+    }
+
+    // Clean '.'/'..' segments textually (posix segment math works for
+    // drive-letter paths too) — host path.resolve would mangle a
+    // foreign-platform path against the local cwd/drive.
+    const norm = path.posix.normalize(filePath.replace(/\\/g, '/'));
+    const showNorm = resolvedShowFolder.replace(/\\/g, '/').replace(/\/+$/, '');
+
+    const normLower = norm.toLowerCase();
+    const showLower = showNorm.toLowerCase();
+    if (normLower === showLower) return '';
+    if (normLower.startsWith(showLower + '/')) {
+        return norm.slice(showNorm.length + 1);
+    }
+
+    // Outside the show folder (or a foreign-platform path): find a same-named
+    // file inside the show folder. Split on '/' after normalization so a
+    // Windows path gets its real basename even on a POSIX host, where
+    // path.basename does not treat '\' as a separator.
+    const basename = norm.split('/').pop() ?? '';
+    return basename ? fileIndex.get(basename.toLowerCase()) : undefined;
+}


### PR DESCRIPTION
Fix a thing that happened when I deployed to Pi