### PR TITLE
Preview 3D: middle-button pan in orbit mode; live view-state capture hook

### DIFF
--- a/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
@@ -381,8 +381,7 @@ export const Preview3D: React.FC<Preview3DProps> = ({
         }
     }, [previewSelection, viewStateBySelection, cameraStateLoaded, previewSettingsStorageKey]);
 
-    // Live view-state capture for share links — pulls the CURRENT camera from the viewer
-    // getter refs rather than the last persisted snapshot.
+    // Live view-state capture for share links.
     useEffect(() => {
         if (!captureViewStateRef) return undefined;
         captureViewStateRef.current = () => {

--- a/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
@@ -143,8 +143,7 @@ export interface Preview3DProps {
     /** When true, viewers use minHeight 0 so the preview fills a flex/dialog container instead of forcing 600px. */
     compact?: boolean;
     /** Registers a callback returning the LIVE view state (mode + current camera + settings) as
-     *  storage-shaped JSON. localStorage only sees the camera on discrete events (mode/selection
-     *  switch, save-as-default), so share links must capture through this instead. */
+     *  storage-shaped JSON */
     captureViewStateRef?: React.MutableRefObject<(() => string | null) | null>;
 }
 

--- a/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Preview3D.tsx
@@ -142,6 +142,10 @@ export interface Preview3DProps {
     mode?: 'standalone' | 'embedded';
     /** When true, viewers use minHeight 0 so the preview fills a flex/dialog container instead of forcing 600px. */
     compact?: boolean;
+    /** Registers a callback returning the LIVE view state (mode + current camera + settings) as
+     *  storage-shaped JSON. localStorage only sees the camera on discrete events (mode/selection
+     *  switch, save-as-default), so share links must capture through this instead. */
+    captureViewStateRef?: React.MutableRefObject<(() => string | null) | null>;
 }
 
 export const Preview3D: React.FC<Preview3DProps> = ({
@@ -161,6 +165,7 @@ export const Preview3D: React.FC<Preview3DProps> = ({
     previewSettingsStorageKey = 'previewSettings',
     mode = 'standalone',
     compact = false,
+    captureViewStateRef,
 }) => {
     const theme = useTheme();
     const preferOrbitControls = useOrbitPreference();
@@ -376,6 +381,29 @@ export const Preview3D: React.FC<Preview3DProps> = ({
             console.error('[Preview3D] Failed to persist preview selection state:', err);
         }
     }, [previewSelection, viewStateBySelection, cameraStateLoaded, previewSettingsStorageKey]);
+
+    // Live view-state capture for share links — pulls the CURRENT camera from the viewer
+    // getter refs rather than the last persisted snapshot.
+    useEffect(() => {
+        if (!captureViewStateRef) return undefined;
+        captureViewStateRef.current = () => {
+            const live3D = getCurrentCameraState3DRef.current?.() ?? cameraState3D;
+            const live2D = getCurrentCameraState2DRef.current?.() ?? cameraState2D;
+            const vs = { mode: viewMode, cameraState2D: live2D, cameraState3D: live3D };
+            return JSON.stringify({
+                pixelSize: previewSettings.pixelSize,
+                brightnessMultiplier: previewSettings.brightnessMultiplier,
+                mode: viewMode,
+                cameraState2D: live2D,
+                cameraState3D: live3D,
+                previewSelection,
+                viewStateBySelection: { ...viewStateBySelection, [previewSelection]: vs },
+            });
+        };
+        return () => {
+            captureViewStateRef.current = null;
+        };
+    }, [captureViewStateRef, viewMode, cameraState2D, cameraState3D, previewSelection, viewStateBySelection, previewSettings]);
 
     // Resolve the server URL (auto-detects Electron port or falls back to same-origin).
     const { url: effectiveFrameServerUrl } = useFrameServerUrl({ frameServerUrl });

--- a/packages/player-ui-components/src/components/preview-3d/Viewer3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Viewer3D.tsx
@@ -1529,8 +1529,6 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
                                 zoomSpeed={1.0}
                                 mouseButtons={{
                                     LEFT: THREE.MOUSE.ROTATE,
-                                    // Middle pans everywhere (freelook + Viewer2D agree); right
-                                    // dollies so a two-button, wheel-less mouse can still zoom.
                                     MIDDLE: THREE.MOUSE.PAN,
                                     RIGHT: THREE.MOUSE.DOLLY,
                                 }}

--- a/packages/player-ui-components/src/components/preview-3d/Viewer3D.tsx
+++ b/packages/player-ui-components/src/components/preview-3d/Viewer3D.tsx
@@ -1421,13 +1421,13 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
                             variant="caption"
                             sx={{ color: 'rgba(255, 255, 255, 0.95)', textShadow: '0 1px 2px rgba(0,0,0,0.8)' }}
                         >
-                            🖱️ Right drag: Pan
+                            🖱️ Middle drag: Pan
                         </Typography>
                         <Typography
                             variant="caption"
                             sx={{ color: 'rgba(255, 255, 255, 0.95)', textShadow: '0 1px 2px rgba(0,0,0,0.8)' }}
                         >
-                            🖱️ Scroll / Middle drag: Zoom
+                            🖱️ Scroll / Right drag: Zoom
                         </Typography>
                     </>
                 ) : (
@@ -1529,8 +1529,10 @@ export const Viewer3D: React.FC<Viewer3DProps> = ({
                                 zoomSpeed={1.0}
                                 mouseButtons={{
                                     LEFT: THREE.MOUSE.ROTATE,
-                                    MIDDLE: THREE.MOUSE.DOLLY,
-                                    RIGHT: THREE.MOUSE.PAN,
+                                    // Middle pans everywhere (freelook + Viewer2D agree); right
+                                    // dollies so a two-button, wheel-less mouse can still zoom.
+                                    MIDDLE: THREE.MOUSE.PAN,
+                                    RIGHT: THREE.MOUSE.DOLLY,
                                 }}
                                 touches={{
                                     ONE: THREE.TOUCH.ROTATE,


### PR DESCRIPTION
Two small changes to the preview-3d components:

- **OrbitControls remap**: middle button now pans and right button zooms (was middle=zoom, right=pan), matching the freelook controller and the 2D viewer's conventions so middle-drag pans in every view. The on-screen hint overlay is updated to match. Touch mappings are unchanged.
- **`captureViewStateRef` prop on `Preview3D`** (optional, additive): registers a callback returning the live view state — current camera (read through the existing viewer getter refs), 2D/3D mode, preview selection, and slider settings — as storage-shaped JSON. Callers that snapshot the view (e.g. share links) need the live camera; localStorage only sees it on discrete events like mode switches.

No behavior change for existing callers that don't pass the new prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)